### PR TITLE
feat: support Xspec models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "corner>=2.2.2",
     "h5py",
     "iminuit",
-    "jax",
+    "jax>=0.4.5",
     "jaxns>=2.4.8",
     "matplotlib",
     "numpy",

--- a/src/elisa/infer/helper.py
+++ b/src/elisa/infer/helper.py
@@ -283,15 +283,20 @@ def get_helper(fit: Fit) -> Helper:
     pname_to_log: dict[ParamName, bool] = {
         pname: model_info.log[pid] for pid, pname in model_info.name.items()
     }
+
+    def get_unit_latex(pid: str) -> str:
+        """Get unit latex string of a parameter."""
+        ustr = model_info.unit[pid]
+        if ustr:
+            try:
+                ustr = Unit(ustr).to_string('latex', fraction=False)
+                ustr = ustr.replace(r'1 \times ', '')
+            except ValueError:
+                ustr = ''
+        return ustr
+
     pname_to_unit: dict[ParamName, str] = {
-        pname: (
-            Unit(ustr)
-            .to_string('latex', fraction=False)
-            .replace(r'1 \times ', '')
-            if (ustr := model_info.unit[pid])
-            else ''
-        )
-        for pid, pname in model_info.name.items()
+        pname: get_unit_latex(pid) for pid, pname in model_info.name.items()
     }
     pname_to_comp_latex: dict[ParamName, str] = {
         pname: model_info.pid_to_comp_latex[pid]

--- a/src/elisa/models/__init__.py
+++ b/src/elisa/models/__init__.py
@@ -1,3 +1,4 @@
+from . import xspec as xspec
 from .add import *  # noqa: F403
 from .conv import *  # noqa: F403
 from .model import (

--- a/src/elisa/models/xspec.py
+++ b/src/elisa/models/xspec.py
@@ -1,0 +1,235 @@
+"""Xspec model wrappers."""
+
+from __future__ import annotations
+
+import warnings
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Literal
+
+import jax
+import jax.numpy as jnp
+
+from elisa.models.model import Component, ParamConfig
+from elisa.util.misc import define_fdjvp
+
+try:
+    from xspex import (
+        abundance as abundance,
+        chatter as chatter,
+        clear_db as clear_db,
+        clear_model_string as clear_model_string,
+        clear_xflt as clear_xflt,
+        cosmology as cosmology,
+        cross_section as cross_section,
+        element_abundance as element_abundance,
+        element_name as element_name,
+        get_db as get_db,
+        get_model_string as get_model_string,
+        get_number_xflt as get_number_xflt,
+        get_xflt as get_xflt,
+        in_xflt as in_xflt,
+        list_models as list_models,
+        number_elements as number_elements,
+        set_db as set_db,
+        set_xflt as set_xflt,
+        version as version,
+    )
+    from xspex.primitive import XSModel as _XSMODEL
+
+    _HAS_XSPEC = True
+except ImportError as e:
+    _XSMODEL = {}
+    _HAS_XSPEC = False
+    warnings.warn(f'Xspec model library is not available: {e}', ImportWarning)
+
+if TYPE_CHECKING:
+    from elisa.util.typing import CompEval
+
+__all__ = []
+
+
+class XspecComponent(Component):
+    """Xspec model wrapper."""
+
+    _kwargs = ('grad_method', 'spec_num')
+    _eval: CompEval | None = None
+
+    def __init__(
+        self,
+        params: dict,
+        latex: str | None,
+        grad_method: Literal['central', 'forward'] | None,
+        spec_num: int | None,
+    ):
+        self.grad_method = grad_method
+        self._spec_num = spec_num
+
+        if spec_num is None:
+            spec_num = 1
+        else:
+            spec_num = int(spec_num)
+        self._spec_num = spec_num
+
+        super().__init__(params, latex)
+
+    @property
+    def grad_method(self) -> Literal['central', 'forward']:
+        """Numerical differentiation method."""
+        return self._grad_method
+
+    @grad_method.setter
+    def grad_method(self, value: Literal['central', 'forward'] | None):
+        if value is None:
+            value: Literal['central'] = 'central'
+
+        if value not in {'central', 'forward'}:
+            raise ValueError(
+                f"supported methods are 'central' and 'forward', but got "
+                f"'{value}'"
+            )
+        self._grad_method = value
+
+    @property
+    def spec_num(self) -> int:
+        """Spectrum number."""
+        return self._spec_num
+
+
+class XspecAdditive(XspecComponent):
+    @property
+    def type(self) -> Literal['add']:
+        return 'add'
+
+    @property
+    def eval(self) -> CompEval:
+        if self._eval is not None:
+            return self._eval
+
+        _integral = jax.jit(define_fdjvp(self._integral, self.grad_method))
+
+        def integral(egrid, params):
+            return params['norm'] * _integral(egrid, params)
+
+        self._eval = jax.jit(integral)
+
+        return self._eval
+
+    @property
+    @abstractmethod
+    def _integral(self):
+        pass
+
+
+class XspecMultiplicative(XspecComponent):
+    @property
+    def type(self) -> Literal['mul']:
+        return 'mul'
+
+    @property
+    def eval(self) -> CompEval:
+        if self._eval is not None:
+            return self._eval
+
+        self._eval = jax.jit(define_fdjvp(self._integral, self.grad_method))
+        return self._eval
+
+    @property
+    @abstractmethod
+    def _integral(self):
+        pass
+
+
+class XspecConvolution(XspecComponent):
+    @property
+    def type(self) -> Literal['conv']:
+        return 'conv'
+
+
+def create_xspec_components():
+    """Create Xspec model classes."""
+    if not _HAS_XSPEC:
+        return {}
+
+    template = '''
+class {name}({component_class}):
+    """Xspec {name} model."""
+
+    _config = (
+        {params_config},
+    )
+
+    @property
+    def _integral(self):
+        spec_num = self.spec_num
+        params_names = [p.name for p in self._config]
+        if self.type == 'add':
+            params_names.remove('norm')
+        fn = XSMODEL['primitive']['{name}']
+
+        def {name}(egrid, params):
+            params = jnp.stack([params[p] for p in params_names])
+            return fn(params, egrid, spec_num)
+
+        return {name}
+'''
+    env = {
+        'ParamConfig': ParamConfig,
+        'XSMODEL': _XSMODEL,
+        'XspecAdditive': XspecAdditive,
+        'XspecMultiplicative': XspecMultiplicative,
+        'jnp': jnp,
+    }
+    models = _XSMODEL['add'] | _XSMODEL['mul']
+    model_classes = {}
+    for name, info in models.items():
+        params_config = []
+        for p in info.parameters:
+            if p.units is None:
+                unit = ''
+            else:
+                unit = p.units
+
+            pname = p.name
+            if pname == 'del':
+                pname = 'delta'
+
+            pmin = p.hardmin
+            pmax = p.hardmax
+            default = p.default
+            if p.paramtype.name == 'Default' and (not pmin < default < pmax):
+                delta = 1e-3 * (pmax - pmin)
+                if pmin == default:
+                    default += delta
+                else:
+                    default -= delta
+
+            params_config.append(
+                rf"ParamConfig('{pname}', r'\mathrm{{{pname}}}', '{unit}', "
+                f'{default}, {pmin}, {pmax}, fixed={p.frozen})'
+            )
+
+        if info.modeltype.name == 'Add':
+            component_class = 'XspecAdditive'
+            params_config.append(
+                r"ParamConfig('norm', r'\mathrm{{norm}}', '', "
+                '1.0, 1e-10, 1e10)'
+            )
+        else:
+            component_class = 'XspecMultiplicative'
+
+        params_config = ',\n        '.join(params_config)
+
+        str_map = {
+            'name': name,
+            'component_class': component_class,
+            'params_config': params_config,
+        }
+        exec(template.format_map(str_map), env, model_classes)
+
+    return model_classes
+
+
+_xs_comps = create_xspec_components()
+locals().update(_xs_comps)
+__all__.append(_xs_comps.keys())
+del _xs_comps

--- a/src/elisa/util/misc.py
+++ b/src/elisa/util/misc.py
@@ -9,8 +9,10 @@ from typing import TYPE_CHECKING
 
 import jax
 import jax.numpy as jnp
-from jax import lax
+from jax import lax, tree_util
+from jax.custom_derivatives import SymbolicZero
 from jax.experimental import host_callback
+from jax.flatten_util import ravel_pytree
 from prettytable import PrettyTable
 from tqdm.auto import tqdm
 
@@ -180,48 +182,63 @@ def define_fdjvp(
             f"'{method}'"
         )
 
-    use_central_diff = method == 'central'
-    fn = jax.custom_jvp(fn)
-
-    @fn.defjvp
-    def _(primals, tangents):
-        # we ignore the tangent for the energy grid
+    def fdjvp(primals, tangents):
         egrid, params = primals
+        egrid_tangent, params_tangent = tangents
+
+        if not isinstance(egrid_tangent, SymbolicZero):
+            raise NotImplementedError('JVP for energy grid is not implemented')
+
         primals_out = fn(egrid, params)
-        f_vmap = jax.vmap(fn, in_axes=(None, 0), out_axes=0)
-        eps = jnp.finfo(egrid.dtype).eps
-        identity = jnp.eye(len(params))
-        params_keys = list(params.keys())
-        params_values = jnp.array(list(params.values()))
-        params_abs = jnp.where(
-            jnp.equal(params_values, 0.0),
-            jnp.ones_like(params_values),
-            jnp.abs(params_values),
+
+        tvals, _ = tree_util.tree_flatten(params_tangent)
+        if any(jnp.shape(v) != () for v in tvals):
+            raise NotImplementedError(
+                'JVP for non-scalar parameter is not implemented'
+            )
+
+        params = lax.stop_gradient(params)
+        non_zero_tangents = [not isinstance(v, SymbolicZero) for v in tvals]
+        idx = [i for i, v in enumerate(non_zero_tangents) if v]
+        idx_arr = jnp.array(idx)
+        nbatch = sum(non_zero_tangents)
+        nparam = len(tvals)
+        params_ravel, revert = ravel_pytree(params)
+        free_params_values = params_ravel[idx_arr]
+        free_params_abs = jnp.where(
+            jnp.equal(free_params_values, 0.0),
+            jnp.ones_like(free_params_values),
+            jnp.abs(free_params_values),
         )
-        params_abs = jnp.expand_dims(params_abs, axis=-1)
+        free_params_abs = jnp.expand_dims(free_params_abs, axis=-1)
+        row_idx = jnp.arange(nbatch)
+        perturb_idx = jnp.zeros((nbatch, nparam)).at[row_idx, idx_arr].set(1.0)
+        params_batch = jnp.full((nbatch, nparam), params_ravel)
+
+        eps = jnp.finfo(egrid.dtype).eps
+        f_vmap = jax.vmap(fn, in_axes=(None, 0), out_axes=0)
+        revert = jax.vmap(revert, in_axes=0, out_axes=0)
 
         # See Numerical Recipes Chapter 5.7
-        if use_central_diff:
-            delta = params_abs * eps ** (1.0 / 3.0)
-            params_pos_perturb = jax.tree_map(
-                jnp.add, params, dict(zip(params_keys, delta * identity))
-            )
+        if method == 'central':
+            perturb = free_params_abs * eps ** (1.0 / 3.0)
+            params_pos_perturb = revert(params_batch + perturb_idx * perturb)
             out_pos_perturb = f_vmap(egrid, params_pos_perturb)
-            params_neg_perturb = jax.tree_map(
-                jnp.subtract, params, dict(zip(params_keys, delta * identity))
-            )
+            params_neg_perturb = revert(params_batch - perturb_idx * perturb)
             out_neg_perturb = f_vmap(egrid, params_neg_perturb)
-            d_out = (out_pos_perturb - out_neg_perturb) / (2.0 * delta)
+            d_out = (out_pos_perturb - out_neg_perturb) / (2.0 * perturb)
         else:
-            delta = params_abs * jnp.sqrt(eps)
-            params_perturb = jax.tree_map(
-                jnp.add, params, dict(zip(params_keys, delta * identity))
-            )
+            perturb = free_params_abs * jnp.sqrt(eps)
+            params_perturb = revert(params_batch + perturb_idx * perturb)
             out_perturb = f_vmap(egrid, params_perturb)
-            d_out = (out_perturb - primals_out) / delta
+            d_out = (out_perturb - primals_out) / perturb
 
-        tangents_out = jnp.array(list(tangents[1].values())) @ d_out
+        free_params_tangent = jnp.array([tvals[i] for i in idx])
+        tangents_out = free_params_tangent @ d_out
         return primals_out, tangents_out
+
+    fn = jax.custom_jvp(fn)
+    fn.defjvp(fdjvp, symbolic_zeros=True)
 
     return fn
 


### PR DESCRIPTION
Support Xspec Models:
- [x] additive models
- [x] multiplicative models
- [x] convolution models

Requires installation of [`xspex`](https://github.com/wcxve/xspex):
```shell
pip install xspex
```

Example:
```python
import matplotlib.pyplot as plt
import numpy as np
from elisa.models import xspec
model = xspec.gsmooth(Sig_6keV=0.05)(xspec.phabs() * xspec.apec())
egrid = np.linspace(0.3, 10.0, 1000)
params = {'phabs.nH': 1.0, 'apec.kT': 1.0, 'apec.norm': 1.0}
ne = model.compile().eval(egrid, None)
plt.step(egrid, np.append(ne, ne[-1]), where='post')
plt.xlabel('Energy [keV]')
plt.ylabel('$N_E$ [cm$^{-2}$ s$^{-1}$ keV$^{-1}$]')
plt.xscale('log')
plt.yscale('log')
```

<img width="625" alt="model plot" src="https://github.com/wcxve/elisa/assets/58248583/082fe597-d3f6-4ced-a9bb-0e4e6e7a86ca">