### PR TITLE
fix: raise error when `BayesFit.nautilus` sampling fails

### DIFF
--- a/src/elisa/infer/fit.py
+++ b/src/elisa/infer/fit.py
@@ -913,7 +913,9 @@ class BayesFit(Fit):
             sampler._transform_back = transform_
             return PosteriorResult(sampler, self._helper, self)
         else:
-            raise UserWarning(r"faild sampling due to limits were reached, please change `n_like_max` or `timeout`, or you can run again if you have set checkpoint `filepath`")
+            raise UserWarning(
+                r'faild sampling due to limits were reached, please change `n_like_max` or `timeout`, or you can run again if you have set checkpoint `filepath`'
+            )
 
     def aies(
         self,

--- a/src/elisa/infer/fit.py
+++ b/src/elisa/infer/fit.py
@@ -908,13 +908,15 @@ class BayesFit(Fit):
         print('Start nested sampling...')
         t0 = time.time()
         success = sampler.run(n_eff=int(ess), **termination_kwargs)
-        if bool(success):
+        if success:
             print(f'Sampling cost {time.time() - t0:.2f} s')
             sampler._transform_back = transform_
             return PosteriorResult(sampler, self._helper, self)
         else:
-            raise UserWarning(
-                r'faild sampling due to limits were reached, please change `n_like_max` or `timeout`, or you can run again if you have set checkpoint `filepath`'
+            raise RuntimeError(
+                'Sampling failed due to limits were reached, please set a '
+                'larger `n_like_max` or `timeout`. You can also run the '
+                'sampler again, providing `filepath` and `resume`.'
             )
 
     def aies(

--- a/src/elisa/infer/fit.py
+++ b/src/elisa/infer/fit.py
@@ -915,8 +915,8 @@ class BayesFit(Fit):
         else:
             raise RuntimeError(
                 'Sampling failed due to limits were reached, please set a '
-                'larger `n_like_max` or `timeout`. You can also run the '
-                'sampler again, providing `filepath` and `resume`.'
+                'larger `n_like_max` or `timeout`. You can also resume the '
+                'sampler from previous one, providing `filepath` and `resume`.'
             )
 
     def aies(

--- a/src/elisa/infer/fit.py
+++ b/src/elisa/infer/fit.py
@@ -907,10 +907,13 @@ class BayesFit(Fit):
         termination_kwargs.setdefault('verbose', True)
         print('Start nested sampling...')
         t0 = time.time()
-        sampler.run(n_eff=int(ess), **termination_kwargs)
-        print(f'Sampling cost {time.time() - t0:.2f} s')
-        sampler._transform_back = transform_
-        return PosteriorResult(sampler, self._helper, self)
+        success = sampler.run(n_eff=int(ess), **termination_kwargs)
+        if bool(success):
+            print(f'Sampling cost {time.time() - t0:.2f} s')
+            sampler._transform_back = transform_
+            return PosteriorResult(sampler, self._helper, self)
+        else:
+            raise UserWarning(r"faild sampling due to limits were reached, please change `n_like_max` or `timeout`, or you can run again if you have set checkpoint `filepath`")
 
     def aies(
         self,


### PR DESCRIPTION
Raise error when `BayesFit.nautilus` sampling fails. The new run can also resume from previous run.