### PR TITLE
Non-JAX nested samplers as optional dependencies

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -5,5 +5,5 @@ PYTHON_VERSIONS = ['3.9', '3.10', '3.11', '3.12']
 
 @nox.session(python=PYTHON_VERSIONS)
 def test(session: nox.Session) -> None:
-    session.install('.[test]')
+    session.install('.[nested_sampler,test]')
     session.run('pytest', '--cov-report=xml', '--cov=elisa', *session.posargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "jax>=0.4.28,<=0.5.2; python_version >= '3.10'",
     "jaxns==2.6.7",
     "matplotlib",
-    "nautilus-sampler==1.0.5",
     "numpy",
     "numpyro>=0.16.1,<=0.17.0",
     "optimistix>=0.0.8,<=0.0.10",
@@ -45,12 +44,12 @@ dependencies = [
     "seaborn<=0.13.2",
     "tinygp<=0.3.0",
     "tqdm",
-    "ultranest==4.4.0",
 ]
 
 
 [project.optional-dependencies]
 xspec = ["xspex"]
+nested_sampler = ["nautilus-sampler==1.0.5", "ultranest==4.4.0"]
 test = ["coverage[toml]", "pytest", "pytest-cov"]
 docs = [
     "ipywidgets",

--- a/src/elisa/infer/fit.py
+++ b/src/elisa/infer/fit.py
@@ -9,10 +9,8 @@ from typing import TYPE_CHECKING
 
 import jax
 import jax.numpy as jnp
-import nautilus
 import numpy as np
 import optimistix as optx
-import ultranest
 from iminuit import Minuit
 from jax.experimental.mesh_utils import create_device_mesh
 from jax.experimental.shard_map import shard_map
@@ -760,6 +758,14 @@ class BayesFit(Fit):
             sampler will not run, but read the log file instead, and make
             sure the data and model setting is the same as the previous run.
         """
+        try:
+            import ultranest
+        except ImportError as e:
+            raise ModuleNotFoundError(
+                'To run the nested sampling of UltraNest, install it by '
+                'by `conda install --channel conda-forge ultranest=4.4.0`'
+            ) from e
+
         if constructor_kwargs is None:
             constructor_kwargs = {}
         else:
@@ -870,6 +876,14 @@ class BayesFit(Fit):
             Extra parameters passed to
             :class:`nautilus.Sampler.run()`.
         """
+        try:
+            import nautilus
+        except ImportError as e:
+            raise ModuleNotFoundError(
+                'To run the nested sampling of Nautilus, install it by '
+                '`pip install nautilus-sampler==1.0.5`'
+            ) from e
+
         if constructor_kwargs is None:
             constructor_kwargs = {}
         else:


### PR DESCRIPTION
## Summary by Sourcery

Make ultranest and nautilus-sampler optional dependencies, installing them only when the user specifies the 'nested_sampler' extra dependency during installation. This change avoids unnecessary dependency installations for users who do not require these samplers and improves the installation experience.

Enhancements:
- Make ultranest and nautilus-sampler optional dependencies.
- Raise a ModuleNotFoundError if the user tries to use ultranest or nautilus without installing them first.
- Update the PosteriorResult class to handle the optional dependencies.
- Update the test session to install the nested_sampler extra dependency.