### PR TITLE
chore: switch to `Codecov`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-        nox-session: ["test"]
 
     steps:
       - name: Checkout
@@ -31,35 +30,15 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install nox coveralls coverage[toml]
+          python -m pip install ".[nested_sampler,test]"
       - name: Run tests
         run: |
-          python -m nox --non-interactive --error-on-missing-interpreter \
-            --session ${{ matrix.nox-session }} --python ${{ matrix.python-version }}
-      - name: Combine and upload coverage
-        run: |
-          python -m coverage xml -i
-          python -m coveralls --service=github
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_PARALLEL: true
-          COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
-
-  coverage:
-    needs: tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v5
+          python -m pytest
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@v5
         with:
-          python-version: "3.9"
-      - name: Finish coverage collection
-        run: |
-          python -m pip install -U pip
-          python -m pip install -U coveralls
-          python -m coveralls --finish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: wcxve/elisa
 
   build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/astro-elisa?color=blue&logo=Python&logoColor=white&style=for-the-badge)](https://pypi.org/project/astro-elisa)
 [![PyPI - Version](https://img.shields.io/pypi/v/astro-elisa?color=blue&logo=PyPI&logoColor=white&style=for-the-badge)](https://pypi.org/project/astro-elisa)
 [![License: GPL v3](https://img.shields.io/github/license/wcxve/elisa?color=blue&logo=open-source-initiative&logoColor=white&style=for-the-badge)](https://www.gnu.org/licenses/gpl-3.0)<br>
-[![Coverage Status](https://img.shields.io/coverallsCoverage/github/wcxve/elisa?logo=Coveralls&logoColor=white&style=for-the-badge)](https://coveralls.io/github/wcxve/elisa)
+[![Coverage Status](https://img.shields.io/codecov/c/github/wcxve/elisa?logo=Codecov&logoColor=white&style=for-the-badge)](https://app.codecov.io/github/wcxve/elisa)
 [![Documentation Status](https://img.shields.io/readthedocs/astro-elisa?logo=Read-the-Docs&logoColor=white&style=for-the-badge)](https://astro-elisa.readthedocs.io/en/latest/?badge=latest)
 
 ``ELISA`` aims to provide a modern and efficient tool to explore and

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ html_theme.sidebar_secondary.remove:
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/astro-elisa?color=blue&logo=Python&logoColor=white&style=for-the-badge)](https://pypi.org/project/astro-elisa)
 [![PyPI - Version](https://img.shields.io/pypi/v/astro-elisa?color=blue&logo=PyPI&logoColor=white&style=for-the-badge)](https://pypi.org/project/astro-elisa)
 [![License: GPL v3](https://img.shields.io/github/license/wcxve/elisa?color=blue&logo=open-source-initiative&logoColor=white&style=for-the-badge)](https://www.gnu.org/licenses/gpl-3.0)<br>
-[![Coverage Status](https://img.shields.io/coverallsCoverage/github/wcxve/elisa?logo=Coveralls&logoColor=white&style=for-the-badge)](https://coveralls.io/github/wcxve/elisa)
+[![Coverage Status](https://img.shields.io/codecov/c/github/wcxve/elisa?logo=Codecov&logoColor=white&style=for-the-badge)](https://app.codecov.io/github/wcxve/elisa)
 [![Documentation Status](https://img.shields.io/readthedocs/astro-elisa?logo=Read-the-Docs&logoColor=white&style=for-the-badge)](https://astro-elisa.readthedocs.io/en/latest/?badge=latest)
 
 ``ELISA`` aims to provide a modern and efficient tool to explore and

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,9 +1,0 @@
-import nox
-
-PYTHON_VERSIONS = ['3.9', '3.10', '3.11', '3.12']
-
-
-@nox.session(python=PYTHON_VERSIONS)
-def test(session: nox.Session) -> None:
-    session.install('.[nested_sampler,test]')
-    session.run('pytest', '--cov-report=xml', '--cov=elisa', *session.posargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,9 @@ lint.select = [
 [tool.ruff.lint.per-file-ignores]
 "docs/notebooks/model-building.ipynb" = ["F403", "F405"]
 
+[tool.pytest]
+ini_options.addopts = "--cov=chronpy --cov-report xml"
+
 [tool.coverage.run]
 branch = true
 parallel = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ lint.select = [
 "docs/notebooks/model-building.ipynb" = ["F403", "F405"]
 
 [tool.pytest]
-ini_options.addopts = "--cov=chronpy --cov-report xml"
+ini_options.addopts = "--cov=elisa --cov-report xml"
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
## Summary by Sourcery

Switch from Coveralls to Codecov for code coverage reporting in the CI workflow

CI:
- Replace Coveralls-based coverage reporting with Codecov in GitHub Actions workflow

Chores:
- Remove noxfile and simplify test configuration
- Update project configuration to use pytest for coverage reporting