### PR TITLE
Add MCMC `thinning` option

### DIFF
--- a/src/elisa/infer/fit.py
+++ b/src/elisa/infer/fit.py
@@ -614,6 +614,7 @@ class BayesFit(Fit):
 
         warmup = int(warmup)
         steps = int(steps)
+        thinning = int(thinning)
 
         device_count = jax.local_device_count()
 
@@ -885,6 +886,7 @@ class BayesFit(Fit):
 
         warmup = int(warmup)
         steps = int(steps)
+        thinning = int(thinning)
 
         if chains is None:
             chains = 4 * len(self._helper.params_names['free'])


### PR DESCRIPTION
This can be used to improve ESS statistics.

## Summary by Sourcery

Add a `thinning` parameter to MCMC sampling methods to improve sampling efficiency and effective sample size (ESS)

New Features:
- Introduced a `thinning` option for MCMC sampling methods to control sample retention

Enhancements:
- Updated MCMC sampling methods to support thinning of MCMC chains
- Modified function signatures to include thinning parameter with default value of 1

Documentation:
- Added documentation for the new `thinning` parameter in method docstrings