### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
           - name: Tests (Lowest Version Deps)
             os: "ubuntu-latest"
-            python-version: "3.9"
+            python-version: "3.10"
             uv-resolution: "lowest-direct"
     steps:
       - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "astro-elisa"
 description = "Efficient library for spectral analysis in high-energy astrophysics."
 readme = "README.md"
-requires-python = ">=3.10, <=3.12"
+requires-python = ">=3.10, <3.13"
 license = "GPL-3.0-or-later"
 authors = [
     { name = "Wang-Chen Xue", email = "wcxuemail@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "astro-elisa"
 description = "Efficient library for spectral analysis in high-energy astrophysics."
 readme = "README.md"
-requires-python = ">=3.9, <3.13"
+requires-python = ">=3.10, <=3.12"
 license = "GPL-3.0-or-later"
 authors = [
     { name = "Wang-Chen Xue", email = "wcxuemail@gmail.com" },
@@ -14,14 +14,12 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "arviz>=0.17.1; python_version < '3.10'",
-    "arviz>=0.18.0,<=0.21.0; python_version >= '3.10'",
+    "arviz>=0.18.0,<=0.21.0",
     "astropy>=5.3,<=6.1.7; python_version < '3.11'",
     "astropy>=5.3,<=7.0.1; python_version >= '3.11'",
     "beautifulsoup4==4.13.4",
@@ -29,10 +27,8 @@ dependencies = [
     "dill==0.4.0",
     "h5py>=3.12.1,<=3.13.0",
     "iminuit>=2.28.0,<=2.30.1",
-    "jax>=0.4.28; python_version < '3.10'",
-    "jax>=0.4.28,<=0.5.2; python_version >= '3.10'",
-    "jaxlib>=0.4.28; python_version < '3.10'",
-    "jaxlib>=0.4.28,<=0.5.2; python_version >= '3.10'",
+    "jax>=0.4.28,<=0.5.2",
+    "jaxlib>=0.4.28,<=0.5.2",
     "jaxns==2.6.7",
     "matplotlib>=3.8.0",
     "numpy>=1.24.1",
@@ -40,8 +36,7 @@ dependencies = [
     "optimistix>=0.0.8,<=0.0.10",
     "prettytable>=3.12.0,<=3.16.0",
     "quadax>=0.2.6,<=0.2.8",
-    "scipy>=1.11.1,<=1.12.0; python_version < '3.10'",
-    "scipy>=1.11.1,<=1.15.2; python_version >= '3.10'",
+    "scipy>=1.11.1,<=1.15.2",
     "seaborn==0.13.2",
     "tinygp==0.3.0",
     "tqdm>=4.66.0",


### PR DESCRIPTION
## Summary by Sourcery

Drop support for Python 3.9 and align project metadata, dependencies, and CI to Python 3.10–3.12.

Enhancements:
- Update the Python requirement and classifiers to restrict support to versions 3.10 through 3.12.
- Remove python_version conditionals in dependency specifications for arviz, jax, jaxlib, and scipy to unify constraints across supported versions.
- Adjust the CI workflow to use Python 3.10 as the minimum test environment.