### PR TITLE
Update non-JAX backend samplers deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       run:
         shell: bash -el {0}
     env:
-      extra: "extra_samplers,xspec"
+      extra: "xspec"
     strategy:
       matrix:
         include:

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -10,7 +10,7 @@ else # assume it's a path
     OUTPUT_DIR=$1
 fi
 
-pip install ..[docs,extra_samplers]  --verbose
+pip install ..[docs]  --verbose
 
 sphinx-apidoc \
     --no-toc \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "blackjax==1.2.5",
     "corner>=2.2.2,<=2.2.3",
     "dill==0.4.0",
+    "emcee==3.1.6",
     "h5py>=3.12.1,<=3.13.0",
     "iminuit>=2.28.0,<=2.30.1",
     "jax>=0.4.28,<0.6.0",
@@ -33,6 +34,7 @@ dependencies = [
     "jaxns==2.6.7",
     "matplotlib>=3.8.0",
     "multiprocess>=0.70.18",
+    "nautilus-sampler==1.0.5",
     "numpy>=1.24.1",
     "numpyro>=0.16.1,<=0.18.0",
     "optimistix>=0.0.8,<=0.0.10",
@@ -42,17 +44,13 @@ dependencies = [
     "seaborn==0.13.2",
     "tinygp==0.3.0",
     "tqdm>=4.66.0",
+    "ultranest==4.4.0",
 ]
 dynamic = ["version"]
 
 
 [project.optional-dependencies]
 xspec = ["xspex>=0.0.7"]
-extra_samplers = [
-    "emcee==3.1.6",
-    "nautilus-sampler==1.0.5",
-    "ultranest==4.4.0",
-]
 test = [
     "coverage[toml]",
     "pytest",

--- a/src/elisa/infer/fit.py
+++ b/src/elisa/infer/fit.py
@@ -1566,11 +1566,6 @@ class BayesFit(Fit):
             .. warning::
                 Setting ``ignore_nan=True`` may fail to spot potential issues
                 with model computation.
-        parallel : bool, optional
-            Whether to parallelize likelihood evaluation. The default is True.
-        n_batch : int, optional
-            Number of likelihood evaluations that are performed at each step
-            for each core when `parallel` is True. The default is 5000.
         constructor_kwargs : dict, optional
             Extra parameters passed to
             :class:`nautilus.Sampler`.
@@ -1584,6 +1579,7 @@ class BayesFit(Fit):
             constructor_kwargs = {}
         else:
             constructor_kwargs = dict(constructor_kwargs)
+        constructor_kwargs.setdefault('pool', get_parallel_number(None))
 
         if termination_kwargs is None:
             termination_kwargs = {}

--- a/src/elisa/infer/samplers/ensemble/emcee.py
+++ b/src/elisa/infer/samplers/ensemble/emcee.py
@@ -8,18 +8,11 @@ import jax
 import jax.numpy as jnp
 import multiprocess as mp
 import numpy as np
+from emcee import EnsembleSampler, State
 from numpyro.infer.initialization import init_to_value
 from tqdm.auto import tqdm
 
 from elisa.infer.samplers.util import get_model_info
-
-try:
-    from emcee import EnsembleSampler as Sampler, State
-except ImportError as e:
-    raise ModuleNotFoundError(
-        'To run the ensemble sampling of emcee, install it by '
-        '`pip install emcee==3.1.6`'
-    ) from e
 
 if TYPE_CHECKING:
     from typing import Callable
@@ -125,7 +118,7 @@ class EmceeSampler:
         def run_sampler(sampler_id, init, rng, queue):
             jitter = rng.uniform(0.99, 1.01, size=(chains, ndim))
             init = init * jitter
-            sampler = Sampler(
+            sampler = EnsembleSampler(
                 chains,
                 ndim,
                 log_prob_fn,

--- a/src/elisa/infer/samplers/ns/nautilus.py
+++ b/src/elisa/infer/samplers/ns/nautilus.py
@@ -6,26 +6,19 @@ from typing import TYPE_CHECKING
 import jax
 import jax.numpy as jnp
 import multiprocess as mp
+import nautilus
+import nautilus.pool as nautilus_pool
 
 from elisa.infer.samplers.util import uniform_reparam_model
-
-try:
-    import nautilus
-
-    # monkey patching the pool for compatibility with JAX
-    import nautilus.pool as nautilus_pool
-
-    nautilus_pool.Pool = mp.Pool
-except ImportError as e:
-    raise ModuleNotFoundError(
-        'To run the nested sampling of Nautilus, install it by '
-        '`pip install nautilus-sampler==1.0.5`'
-    ) from e
 
 if TYPE_CHECKING:
     from typing import Callable
 
     from numpy.typing import NDArray
+
+
+# monkey patching the pool for compatibility with JAX
+nautilus_pool.Pool = mp.Pool
 
 
 class NautilusSampler:

--- a/src/elisa/infer/samplers/ns/ultranest.py
+++ b/src/elisa/infer/samplers/ns/ultranest.py
@@ -7,17 +7,9 @@ from typing import TYPE_CHECKING
 import jax
 import jax.numpy as jnp
 import numpy as np
+from ultranest import ReactiveNestedSampler, read_file
 
 from elisa.infer.samplers.util import ravel_params_names, uniform_reparam_model
-
-try:
-    from ultranest import ReactiveNestedSampler, read_file
-except ImportError as e:
-    raise ModuleNotFoundError(
-        'To run the nested sampling of UltraNest, install it by '
-        '`conda install --channel conda-forge ultranest=4.4.0`, '
-        'or `pip install ultranest==4.4.0`'
-    ) from e
 
 if TYPE_CHECKING:
     from typing import Callable


### PR DESCRIPTION
## Summary by Sourcery

Simplify non-JAX sampler backend dependency management by hoisting emcee, nautilus-sampler, and ultranest into core dependencies, removing conditional imports from sampler modules, and updating CI and docs accordingly.

Enhancements:
- Remove conditional import and fallback logic for Nautilus, emcee, and UltraNest samplers in code modules
- Simplify backend samplers by using direct imports and JAX-compatible pool monkey-patching

Build:
- Add emcee, nautilus-sampler, and ultranest to core project dependencies and remove the extra_samplers optional group

CI:
- Update CI workflow to drop the extra_samplers environment matrix entry

Documentation:
- Adjust documentation build script to stop installing the removed extra_samplers extras