### PR TITLE
chore: update to Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ build.targets.wheel.packages = ["src/elisa"]
 
 [tool.ruff]
 line-length = 79
-target-version = "py39"
+target-version = "py310"
 extend-exclude = [
     "src/elisa/infer/samplers/ns/jaxns.py",
 ]
@@ -126,13 +126,19 @@ lint.select = [
 "docs/notebooks/model-building.ipynb" = ["F403", "F405"]
 
 [tool.pytest]
-ini_options.addopts = "-n auto --cov=elisa --cov-report xml"
+ini_options.addopts = "-n auto --cov --cov-report xml"
 
 [tool.coverage]
+run.concurrency = [
+    "thread",
+    "multiprocessing",
+]
 run.omit = [
     "src/elisa/infer/samplers/ns/jaxns.py",
     "src/elisa/models/tables",
 ]
+run.relative_files = true
+run.source = ["src"]
 report.exclude_also = [
     # Have to re-enable the standard pragma
     "pragma: no cover",
@@ -148,3 +154,4 @@ report.exclude_also = [
     # Don't complain about abstract methods' implementations
     '@(abc\.)?abstractmethod',
 ]
+report.show_missing = true

--- a/src/elisa/data/grouping.py
+++ b/src/elisa/data/grouping.py
@@ -630,7 +630,7 @@ def group_sig_normal(
 
     group_count = 0.0
     group_variance = 0.0
-    for i, (d, e) in enumerate(zip(count, error)):
+    for i, (d, e) in enumerate(zip(count, error, strict=False)):
         group_count += d
         group_variance += e * e
         x = group_count - sig * np.sqrt(group_variance)
@@ -706,7 +706,7 @@ def group_sig_lima(
 
     group_on = 0.0
     group_off = 0.0
-    for i, (j, k) in enumerate(zip(n_on, n_off)):
+    for i, (j, k) in enumerate(zip(n_on, n_off, strict=False)):
         group_on += j
         group_off += k
         group_sig = significance_lima(group_on, group_off, a)
@@ -786,7 +786,7 @@ def group_sig_gv(
     group_n = 0.0
     group_b = 0.0
     group_var = 0.0
-    for i, (ni, bi, si) in enumerate(zip(n, b, s)):
+    for i, (ni, bi, si) in enumerate(zip(n, b, s, strict=False)):
         group_n += ni
         group_b += bi
         group_var += si * si

--- a/src/elisa/data/grouping.py
+++ b/src/elisa/data/grouping.py
@@ -630,7 +630,7 @@ def group_sig_normal(
 
     group_count = 0.0
     group_variance = 0.0
-    for i, (d, e) in enumerate(zip(count, error, strict=False)):
+    for i, (d, e) in enumerate(zip(count, error, strict=True)):
         group_count += d
         group_variance += e * e
         x = group_count - sig * np.sqrt(group_variance)
@@ -706,7 +706,7 @@ def group_sig_lima(
 
     group_on = 0.0
     group_off = 0.0
-    for i, (j, k) in enumerate(zip(n_on, n_off, strict=False)):
+    for i, (j, k) in enumerate(zip(n_on, n_off, strict=True)):
         group_on += j
         group_off += k
         group_sig = significance_lima(group_on, group_off, a)
@@ -786,7 +786,7 @@ def group_sig_gv(
     group_n = 0.0
     group_b = 0.0
     group_var = 0.0
-    for i, (ni, bi, si) in enumerate(zip(n, b, s, strict=False)):
+    for i, (ni, bi, si) in enumerate(zip(n, b, s, strict=True)):
         group_n += ni
         group_b += bi
         group_var += si * si

--- a/src/elisa/infer/fit.py
+++ b/src/elisa/infer/fit.py
@@ -127,11 +127,11 @@ class Fit(ABC):
         num_suffix = build_namespace(name_with_data_suffix)['suffix_num']
         cname = add_suffix(cname, num_suffix, True)
         cname = add_suffix(cname, data_suffix, False)
-        cid_to_name = dict(zip(cid, cname, strict=False))
+        cid_to_name = dict(zip(cid, cname, strict=True))
         latex = [comp.latex for comp in comps]
         latex = add_suffix(latex, num_suffix, True, latex=True)
         latex = add_suffix(latex, data_suffix, False, latex=True, mathrm=True)
-        cid_to_latex = dict(zip(cid, latex, strict=False))
+        cid_to_latex = dict(zip(cid, latex, strict=True))
 
         # get model info
         self._model_info: ModelInfo = get_model_info(
@@ -141,12 +141,12 @@ class Fit(ABC):
         # first filter out duplicated models then compile the remaining models,
         # this is intended to avoid re-compilation of the same model
         models_id = [id(m) for m in models]
-        mid_to_model = dict(zip(models_id, models, strict=False))
+        mid_to_model = dict(zip(models_id, models, strict=True))
         compiled_model = {
             mid: m.compile(model_info=self._model_info)
             for mid, m in mid_to_model.items()
         }
-        data_to_mid = dict(zip(data_names, models_id, strict=False))
+        data_to_mid = dict(zip(data_names, models_id, strict=True))
         self._model = {
             name: compiled_model[mid] for name, mid in data_to_mid.items()
         }
@@ -277,7 +277,7 @@ class Fit(ABC):
                 self._data,
                 (m.name for m in self._model.values()),
                 self._stat.values(),
-                strict=False,
+                strict=True,
             )
         )
         self._tab_likelihood: PrettyTable = make_pretty_table(fields, rows)
@@ -466,7 +466,7 @@ class Fit(ABC):
             raise ValueError(msg)
 
         # check if correctly using stat
-        for d, s in zip(data_list, stat_list, strict=False):
+        for d, s in zip(data_list, stat_list, strict=True):
             check_stat(d, s)
 
         return data_list, model_list, stat_list

--- a/src/elisa/infer/fit.py
+++ b/src/elisa/infer/fit.py
@@ -104,7 +104,7 @@ class Fit(ABC):
         # add names of data sets to be fit with it as its name/latex suffix
         data_names = [d.name for d in data]
         data_to_cid = {
-            n: m._comps_id for n, m in zip(data_names, models, strict=False)
+            n: m._comps_id for n, m in zip(data_names, models, strict=True)
         }
         cid_to_comp = {c._id: c for m in models for c in m._comps}
         cid = list(cid_to_comp.keys())
@@ -122,7 +122,7 @@ class Fit(ABC):
         data_suffix = list(cid_to_data_suffix.values())
         cname = [comp.name for comp in comps]
         name_with_data_suffix = list(
-            map(''.join, zip(cname, data_suffix, strict=False))
+            map(''.join, zip(cname, data_suffix, strict=True))
         )
         num_suffix = build_namespace(name_with_data_suffix)['suffix_num']
         cname = add_suffix(cname, num_suffix, True)
@@ -153,10 +153,10 @@ class Fit(ABC):
 
         # store data, stat, seed
         self._data: dict[str, FixedData] = dict(
-            zip(data_names, data, strict=False)
+            zip(data_names, data, strict=True)
         )
         self._stat: dict[str, Statistic] = dict(
-            zip(data_names, stats, strict=False)
+            zip(data_names, stats, strict=True)
         )
         self._seed: int = int(seed)
 
@@ -1156,7 +1156,7 @@ class BayesFit(Fit):
         high = init + jitter
         init = rng.uniform(low, high, size=(chains, len(init)))
         init = dict(
-            zip(self._helper.params_names['free'], init.T, strict=False)
+            zip(self._helper.params_names['free'], init.T, strict=True)
         )
 
         def do_mcmc(rng_key):

--- a/src/elisa/infer/fit.py
+++ b/src/elisa/infer/fit.py
@@ -45,7 +45,8 @@ from elisa.util.misc import (
 )
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Literal
+    from collections.abc import Callable
+    from typing import Any, Literal
 
     from jaxlib.xla_client import Device
     from prettytable import PrettyTable
@@ -102,7 +103,9 @@ class Fit(ABC):
         # if a component is not fit with all datasets,
         # add names of data sets to be fit with it as its name/latex suffix
         data_names = [d.name for d in data]
-        data_to_cid = {n: m._comps_id for n, m in zip(data_names, models)}
+        data_to_cid = {
+            n: m._comps_id for n, m in zip(data_names, models, strict=False)
+        }
         cid_to_comp = {c._id: c for m in models for c in m._comps}
         cid = list(cid_to_comp.keys())
         comps = list(cid_to_comp.values())
@@ -118,15 +121,17 @@ class Fit(ABC):
         }
         data_suffix = list(cid_to_data_suffix.values())
         cname = [comp.name for comp in comps]
-        name_with_data_suffix = list(map(''.join, zip(cname, data_suffix)))
+        name_with_data_suffix = list(
+            map(''.join, zip(cname, data_suffix, strict=False))
+        )
         num_suffix = build_namespace(name_with_data_suffix)['suffix_num']
         cname = add_suffix(cname, num_suffix, True)
         cname = add_suffix(cname, data_suffix, False)
-        cid_to_name = dict(zip(cid, cname))
+        cid_to_name = dict(zip(cid, cname, strict=False))
         latex = [comp.latex for comp in comps]
         latex = add_suffix(latex, num_suffix, True, latex=True)
         latex = add_suffix(latex, data_suffix, False, latex=True, mathrm=True)
-        cid_to_latex = dict(zip(cid, latex))
+        cid_to_latex = dict(zip(cid, latex, strict=False))
 
         # get model info
         self._model_info: ModelInfo = get_model_info(
@@ -136,19 +141,23 @@ class Fit(ABC):
         # first filter out duplicated models then compile the remaining models,
         # this is intended to avoid re-compilation of the same model
         models_id = [id(m) for m in models]
-        mid_to_model = dict(zip(models_id, models))
+        mid_to_model = dict(zip(models_id, models, strict=False))
         compiled_model = {
             mid: m.compile(model_info=self._model_info)
             for mid, m in mid_to_model.items()
         }
-        data_to_mid = dict(zip(data_names, models_id))
+        data_to_mid = dict(zip(data_names, models_id, strict=False))
         self._model = {
             name: compiled_model[mid] for name, mid in data_to_mid.items()
         }
 
         # store data, stat, seed
-        self._data: dict[str, FixedData] = dict(zip(data_names, data))
-        self._stat: dict[str, Statistic] = dict(zip(data_names, stats))
+        self._data: dict[str, FixedData] = dict(
+            zip(data_names, data, strict=False)
+        )
+        self._stat: dict[str, Statistic] = dict(
+            zip(data_names, stats, strict=False)
+        )
         self._seed: int = int(seed)
 
         # make model information table
@@ -268,6 +277,7 @@ class Fit(ABC):
                 self._data,
                 (m.name for m in self._model.values()),
                 self._stat.values(),
+                strict=False,
             )
         )
         self._tab_likelihood: PrettyTable = make_pretty_table(fields, rows)
@@ -456,7 +466,7 @@ class Fit(ABC):
             raise ValueError(msg)
 
         # check if correctly using stat
-        for d, s in zip(data_list, stat_list):
+        for d, s in zip(data_list, stat_list, strict=False):
             check_stat(d, s)
 
         return data_list, model_list, stat_list
@@ -1145,7 +1155,9 @@ class BayesFit(Fit):
         low = init - jitter
         high = init + jitter
         init = rng.uniform(low, high, size=(chains, len(init)))
-        init = dict(zip(self._helper.params_names['free'], init.T))
+        init = dict(
+            zip(self._helper.params_names['free'], init.T, strict=False)
+        )
 
         def do_mcmc(rng_key):
             sampler.run(rng_key, init_params=init)

--- a/src/elisa/infer/helper.py
+++ b/src/elisa/infer/helper.py
@@ -401,7 +401,7 @@ def get_helper(fit: Fit) -> Helper:
     def arr_to_dic(arr: JAXArray) -> ParamNameValMapping:
         """Covert free parameters from an array to a dict."""
         assert len(arr) == len(free_names)
-        return dict(zip(free_names, arr, strict=False))
+        return dict(zip(free_names, arr, strict=True))
 
     @jax.jit
     def dic_to_arr(dic: ParamNameValMapping) -> JAXArray:
@@ -903,7 +903,7 @@ def get_helper(fit: Fit) -> Helper:
             'all': params_names,
         },
         params_default=unconstr_dic_to_params_dic(
-            dict(zip(free_names, default_unconstr_arr, strict=False))
+            dict(zip(free_names, default_unconstr_arr, strict=True))
         ),
         params_setup=model_info.setup,
         params_latex=pname_to_latex,

--- a/src/elisa/infer/helper.py
+++ b/src/elisa/infer/helper.py
@@ -31,8 +31,8 @@ from elisa.util.misc import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-    from typing import Callable, Literal
+    from collections.abc import Callable, Sequence
+    from typing import Literal
 
     from numpyro.distributions import Distribution
 
@@ -401,7 +401,7 @@ def get_helper(fit: Fit) -> Helper:
     def arr_to_dic(arr: JAXArray) -> ParamNameValMapping:
         """Covert free parameters from an array to a dict."""
         assert len(arr) == len(free_names)
-        return dict(zip(free_names, arr))
+        return dict(zip(free_names, arr, strict=False))
 
     @jax.jit
     def dic_to_arr(dic: ParamNameValMapping) -> JAXArray:
@@ -903,7 +903,7 @@ def get_helper(fit: Fit) -> Helper:
             'all': params_names,
         },
         params_default=unconstr_dic_to_params_dic(
-            dict(zip(free_names, default_unconstr_arr))
+            dict(zip(free_names, default_unconstr_arr, strict=False))
         ),
         params_setup=model_info.setup,
         params_latex=pname_to_latex,

--- a/src/elisa/infer/likelihood.py
+++ b/src/elisa/infer/likelihood.py
@@ -14,7 +14,7 @@ from numpyro.distributions import Normal, Poisson
 from numpyro.distributions.util import validate_sample
 
 if TYPE_CHECKING:
-    from typing import Callable
+    from collections.abc import Callable
 
     from elisa.data.base import FixedData
     from elisa.util.typing import (

--- a/src/elisa/infer/results.py
+++ b/src/elisa/infer/results.py
@@ -299,7 +299,7 @@ class MLEResult(FitResult):
             covar = helper.params_covar(self._mle_unconstr, covar_unconstr)
 
         var2pos = dict(
-            zip(helper.params_names['all'], range(len(mle)), strict=False)
+            zip(helper.params_names['all'], range(len(mle)), strict=True)
         )
         self._covar = CovarMatrix(var2pos)
         self._covar[:] = covar
@@ -310,8 +310,8 @@ class MLEResult(FitResult):
         self._mle = dict(
             zip(
                 helper.params_names['all'],
-                zip(mle, err, strict=False),
-                strict=False,
+                zip(mle, err, strict=True),
+                strict=True,
             )
         )
 
@@ -529,7 +529,7 @@ class MLEResult(FitResult):
                 @jax.jit
                 def jacobian(params_arr):
                     params_dic = dict(
-                        zip(params_mle.keys(), params_arr, strict=False)
+                        zip(params_mle.keys(), params_arr, strict=True)
                     )
                     fn_arr = jnp.array([f(params_dic) for f in fn.values()])
                     return jnp.hstack([params_arr, fn_arr])
@@ -572,7 +572,7 @@ class MLEResult(FitResult):
             raise ValueError("method must be either 'hess' or 'boot'")
 
         names = tuple(params) + tuple(fn.keys())
-        var2pos = dict(zip(names, range(len(names)), strict=False))
+        var2pos = dict(zip(names, range(len(names)), strict=True))
         matrix = CovarMatrix(var2pos)
         mask = np.array(
             [p in params for p in params_mle] + [True] * len(fn),
@@ -824,7 +824,7 @@ class MLEResult(FitResult):
         @jax.jit
         def loss(x: np.ndarray):
             """Joint loss of params and func of params."""
-            unconstr_dic = dict(zip(params_free, x[1:], strict=False))
+            unconstr_dic = dict(zip(params_free, x[1:], strict=True))
             params = helper.unconstr_dic_to_params_dic(unconstr_dic)
             fn_value = fn(params)
             s1 = fn_value / x[0] - 1.0
@@ -1475,7 +1475,7 @@ class PosteriorResult(FitResult):
         bins = np.asarray([-np.inf, 0.5, 0.7, 1, np.inf])
         counts, *_ = np.histogram(loo.pareto_k.values, bins)
         pct = [f'{i:.1%}' for i in counts / np.sum(counts)]
-        rows = list(zip(ranges, flags, counts, pct, strict=False))
+        rows = list(zip(ranges, flags, counts, pct, strict=True))
         names = ['Range', 'Flag', 'Count', 'Pct.']
         k_tab = make_pretty_table(names, rows)
 
@@ -1551,7 +1551,7 @@ class PosteriorResult(FitResult):
         covar = np.cov(samples, rowvar=False)
 
         names = tuple(params) + tuple(fn.keys())
-        var2pos = dict(zip(names, range(len(names)), strict=False))
+        var2pos = dict(zip(names, range(len(names)), strict=True))
         matrix = CovarMatrix(var2pos)
         mask = np.array(
             [p in params for p in params_dist] + [True] * len(fn),
@@ -2138,7 +2138,7 @@ class PosteriorResult(FitResult):
             err = np.sqrt(np.diagonal(cov))
             params_names = helper.params_names['all']
             mle_result['params'] = dict(
-                zip(params_names, zip(mle, err, strict=False), strict=False)
+                zip(params_names, zip(mle, err, strict=True), strict=True)
             )
 
             sites = jax.device_get(jax.jit(helper.get_sites)(mle_unconstr))

--- a/src/elisa/infer/results.py
+++ b/src/elisa/infer/results.py
@@ -298,14 +298,22 @@ class MLEResult(FitResult):
             covar_unconstr = jnp.array(minuit.covariance, float)
             covar = helper.params_covar(self._mle_unconstr, covar_unconstr)
 
-        var2pos = dict(zip(helper.params_names['all'], range(len(mle))))
+        var2pos = dict(
+            zip(helper.params_names['all'], range(len(mle)), strict=False)
+        )
         self._covar = CovarMatrix(var2pos)
         self._covar[:] = covar
 
         err = jnp.sqrt(jnp.diagonal(covar))
 
         # MLE of model params in constrained space
-        self._mle = dict(zip(helper.params_names['all'], zip(mle, err)))
+        self._mle = dict(
+            zip(
+                helper.params_names['all'],
+                zip(mle, err, strict=False),
+                strict=False,
+            )
+        )
 
         # model deviance at MLE
         self._deviance = jax.jit(helper.deviance)(self._mle_unconstr)
@@ -520,7 +528,9 @@ class MLEResult(FitResult):
                 @jax.jacobian
                 @jax.jit
                 def jacobian(params_arr):
-                    params_dic = dict(zip(params_mle.keys(), params_arr))
+                    params_dic = dict(
+                        zip(params_mle.keys(), params_arr, strict=False)
+                    )
                     fn_arr = jnp.array([f(params_dic) for f in fn.values()])
                     return jnp.hstack([params_arr, fn_arr])
 
@@ -562,7 +572,7 @@ class MLEResult(FitResult):
             raise ValueError("method must be either 'hess' or 'boot'")
 
         names = tuple(params) + tuple(fn.keys())
-        var2pos = dict(zip(names, range(len(names))))
+        var2pos = dict(zip(names, range(len(names)), strict=False))
         matrix = CovarMatrix(var2pos)
         mask = np.array(
             [p in params for p in params_mle] + [True] * len(fn),
@@ -814,7 +824,7 @@ class MLEResult(FitResult):
         @jax.jit
         def loss(x: np.ndarray):
             """Joint loss of params and func of params."""
-            unconstr_dic = dict(zip(params_free, x[1:]))
+            unconstr_dic = dict(zip(params_free, x[1:], strict=False))
             params = helper.unconstr_dic_to_params_dic(unconstr_dic)
             fn_value = fn(params)
             s1 = fn_value / x[0] - 1.0
@@ -1465,7 +1475,7 @@ class PosteriorResult(FitResult):
         bins = np.asarray([-np.inf, 0.5, 0.7, 1, np.inf])
         counts, *_ = np.histogram(loo.pareto_k.values, bins)
         pct = [f'{i:.1%}' for i in counts / np.sum(counts)]
-        rows = list(zip(ranges, flags, counts, pct))
+        rows = list(zip(ranges, flags, counts, pct, strict=False))
         names = ['Range', 'Flag', 'Count', 'Pct.']
         k_tab = make_pretty_table(names, rows)
 
@@ -1541,7 +1551,7 @@ class PosteriorResult(FitResult):
         covar = np.cov(samples, rowvar=False)
 
         names = tuple(params) + tuple(fn.keys())
-        var2pos = dict(zip(names, range(len(names))))
+        var2pos = dict(zip(names, range(len(names)), strict=False))
         matrix = CovarMatrix(var2pos)
         mask = np.array(
             [p in params for p in params_dist] + [True] * len(fn),
@@ -2127,7 +2137,9 @@ class PosteriorResult(FitResult):
             mle, cov = jax.device_get(helper.get_mle(mle_unconstr))
             err = np.sqrt(np.diagonal(cov))
             params_names = helper.params_names['all']
-            mle_result['params'] = dict(zip(params_names, zip(mle, err)))
+            mle_result['params'] = dict(
+                zip(params_names, zip(mle, err, strict=False), strict=False)
+            )
 
             sites = jax.device_get(jax.jit(helper.get_sites)(mle_unconstr))
 

--- a/src/elisa/infer/samplers/blackjax/nuts.py
+++ b/src/elisa/infer/samplers/blackjax/nuts.py
@@ -14,7 +14,7 @@ from numpyro.infer.util import init_to_uniform, initialize_model
 from numpyro.util import identity, is_prng_key
 
 if TYPE_CHECKING:
-    from typing import Callable
+    from collections.abc import Callable
 
     from blackjax.mcmc.metrics import MetricTypes
 

--- a/src/elisa/infer/samplers/ensemble/emcee.py
+++ b/src/elisa/infer/samplers/ensemble/emcee.py
@@ -15,7 +15,7 @@ from tqdm.auto import tqdm
 from elisa.infer.samplers.util import get_model_info
 
 if TYPE_CHECKING:
-    from typing import Callable
+    from collections.abc import Callable
 
     from numpy.typing import NDArray
 

--- a/src/elisa/infer/samplers/ns/nautilus.py
+++ b/src/elisa/infer/samplers/ns/nautilus.py
@@ -12,7 +12,7 @@ import nautilus.pool as nautilus_pool
 from elisa.infer.samplers.util import uniform_reparam_model
 
 if TYPE_CHECKING:
-    from typing import Callable
+    from collections.abc import Callable
 
     from numpy.typing import NDArray
 

--- a/src/elisa/infer/samplers/ns/ultranest.py
+++ b/src/elisa/infer/samplers/ns/ultranest.py
@@ -12,7 +12,7 @@ from ultranest import ReactiveNestedSampler, read_file
 from elisa.infer.samplers.util import ravel_params_names, uniform_reparam_model
 
 if TYPE_CHECKING:
-    from typing import Callable
+    from collections.abc import Callable
 
     from numpy.typing import NDArray
 

--- a/src/elisa/infer/samplers/util.py
+++ b/src/elisa/infer/samplers/util.py
@@ -22,7 +22,7 @@ from numpyro.infer.util import (
 )
 
 if TYPE_CHECKING:
-    from typing import Callable
+    from collections.abc import Callable
 
     from numpy import dtype, floating
     from numpy.typing import NDArray

--- a/src/elisa/infer/samplers/util.py
+++ b/src/elisa/infer/samplers/util.py
@@ -173,7 +173,7 @@ def uniform_reparam_transform(d):
 
     elif isinstance(
         d,
-        (dist.Independent, dist.ExpandedDistribution, dist.MaskedDistribution),
+        dist.Independent | dist.ExpandedDistribution | dist.MaskedDistribution,
     ):
 
         def transform(q):

--- a/src/elisa/models/conv.py
+++ b/src/elisa/models/conv.py
@@ -11,7 +11,7 @@ import jax.numpy as jnp
 from elisa.models.model import ConvolutionComponent, ParamConfig
 
 if TYPE_CHECKING:
-    from typing import Callable
+    from collections.abc import Callable
 
     from elisa.util.typing import ConvolveEval, JAXArray, NameValMapping
 

--- a/src/elisa/models/model.py
+++ b/src/elisa/models/model.py
@@ -73,12 +73,12 @@ class Model(ABC):
         self._comps_id = tuple(comp._id for comp in comps)
 
         cname = build_namespace([c.name for c in comps])['namespace']
-        cid_to_cname = dict(zip(self._comps_id, cname, strict=False))
+        cid_to_cname = dict(zip(self._comps_id, cname, strict=True))
         self._cid_to_cname = cid_to_cname
 
         self.__name = self._id_to_label(cid_to_cname, 'name')
 
-        for name, comp in zip(cid_to_cname.values(), comps, strict=False):
+        for name, comp in zip(cid_to_cname.values(), comps, strict=True):
             setattr(self, name, comp)
 
         self.__initialized = True
@@ -87,7 +87,7 @@ class Model(ABC):
     def _cid_to_clatex(self) -> CompIDStrMapping:
         clatex = [c.latex for c in self._comps]
         clatex = build_namespace(clatex, latex=True)['namespace']
-        return dict(zip(self._comps_id, clatex, strict=False))
+        return dict(zip(self._comps_id, clatex, strict=True))
 
     def compile(self, *, model_info: ModelInfo | None = None) -> CompiledModel:
         """Compile the model for fast evaluation.
@@ -160,7 +160,7 @@ class Model(ABC):
             zip(
                 self._comps_id,
                 build_namespace(latex, latex=True)['namespace'],
-                strict=False,
+                strict=True,
             )
         )
 
@@ -241,7 +241,7 @@ class Model(ABC):
             egrid: JAXArray, params: ParamIDValMapping
         ) -> dict[tuple[str, str], JAXArray]:
             """The evaluation function of additive components."""
-            return dict(zip(comps_labels, _fn(egrid, params), strict=False))
+            return dict(zip(comps_labels, _fn(egrid, params), strict=True))
 
         return fn
 
@@ -326,7 +326,7 @@ class CompiledModel:
         self._value_sequence_to_params: Callable[
             [Sequence[JAXFloat]], ParamIDValMapping
         ] = jax.jit(
-            lambda sequence: dict(zip(params_id, sequence, strict=False))
+            lambda sequence: dict(zip(params_id, sequence, strict=True))
         )
         fixed_name_to_pid = {model_info.name[pid]: pid for pid in fixed_id}
         pname_pid_all = pname_to_pid | fixed_name_to_pid
@@ -361,7 +361,7 @@ class CompiledModel:
 
     def _prepare_eval(self, params: ArrayLike | Sequence | Mapping | None):
         """Check if `params` is valid for the model."""
-        if isinstance(params, (np.ndarray, jax.Array, Sequence)):
+        if isinstance(params, np.ndarray | jax.Array | Sequence):
             params = jnp.atleast_1d(jnp.asarray(params, float))
             if params.shape[-1] != self._nparam:
                 raise ValueError(
@@ -1427,7 +1427,7 @@ def _param_setter(name: str, idx: int) -> Callable[[Component, Any], None]:
             )
 
         elif isinstance(
-            param, (float, int, jnp.number, jnp.ndarray, np.ndarray)
+            param, float | int | jnp.number | jnp.ndarray | np.ndarray
         ):
             # fixed to the given value
             if jnp.shape(param) != ():
@@ -2125,7 +2125,7 @@ def get_model_info(
 
     # name mapping from aux params id to name
     name_mapping: ParamIDStrMapping = dict(
-        zip(aux_params.keys(), aux_names, strict=False)
+        zip(aux_params.keys(), aux_names, strict=True)
     )
 
     # record name mapping of params directly assigned to a component
@@ -2143,7 +2143,7 @@ def get_model_info(
     # record the LaTeX format of aux parameters
     aux_latex = [params_info[pid].latex for pid in aux_params]
     aux_latex = build_namespace(aux_latex, latex=True, prime=True)['namespace']
-    latex_mapping = dict(zip(aux_params.keys(), aux_latex, strict=False))
+    latex_mapping = dict(zip(aux_params.keys(), aux_latex, strict=True))
 
     # record the LaTeX format of component parameters from _config
     latex_mapping |= {

--- a/src/elisa/models/model.py
+++ b/src/elisa/models/model.py
@@ -22,7 +22,8 @@ from elisa.models.parameter import Parameter, UniformParameter
 from elisa.util.misc import build_namespace, define_fdjvp, make_pretty_table
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Literal
+    from collections.abc import Callable
+    from typing import Any, Literal
 
     from astropy.cosmology.flrw.lambdacdm import LambdaCDM
     from numpyro.distributions import Distribution
@@ -72,12 +73,12 @@ class Model(ABC):
         self._comps_id = tuple(comp._id for comp in comps)
 
         cname = build_namespace([c.name for c in comps])['namespace']
-        cid_to_cname = dict(zip(self._comps_id, cname))
+        cid_to_cname = dict(zip(self._comps_id, cname, strict=False))
         self._cid_to_cname = cid_to_cname
 
         self.__name = self._id_to_label(cid_to_cname, 'name')
 
-        for name, comp in zip(cid_to_cname.values(), comps):
+        for name, comp in zip(cid_to_cname.values(), comps, strict=False):
             setattr(self, name, comp)
 
         self.__initialized = True
@@ -86,7 +87,7 @@ class Model(ABC):
     def _cid_to_clatex(self) -> CompIDStrMapping:
         clatex = [c.latex for c in self._comps]
         clatex = build_namespace(clatex, latex=True)['namespace']
-        return dict(zip(self._comps_id, clatex))
+        return dict(zip(self._comps_id, clatex, strict=False))
 
     def compile(self, *, model_info: ModelInfo | None = None) -> CompiledModel:
         """Compile the model for fast evaluation.
@@ -159,6 +160,7 @@ class Model(ABC):
             zip(
                 self._comps_id,
                 build_namespace(latex, latex=True)['namespace'],
+                strict=False,
             )
         )
 
@@ -239,7 +241,7 @@ class Model(ABC):
             egrid: JAXArray, params: ParamIDValMapping
         ) -> dict[tuple[str, str], JAXArray]:
             """The evaluation function of additive components."""
-            return dict(zip(comps_labels, _fn(egrid, params)))
+            return dict(zip(comps_labels, _fn(egrid, params), strict=False))
 
         return fn
 
@@ -323,7 +325,9 @@ class CompiledModel:
         self._params_default = dict(model_info.default)
         self._value_sequence_to_params: Callable[
             [Sequence[JAXFloat]], ParamIDValMapping
-        ] = jax.jit(lambda sequence: dict(zip(params_id, sequence)))
+        ] = jax.jit(
+            lambda sequence: dict(zip(params_id, sequence, strict=False))
+        )
         fixed_name_to_pid = {model_info.name[pid]: pid for pid in fixed_id}
         pname_pid_all = pname_to_pid | fixed_name_to_pid
         self._value_mapping_to_params: Callable[
@@ -2120,7 +2124,9 @@ def get_model_info(
     aux_names = build_namespace(aux_names, prime=True)['namespace']
 
     # name mapping from aux params id to name
-    name_mapping: ParamIDStrMapping = dict(zip(aux_params.keys(), aux_names))
+    name_mapping: ParamIDStrMapping = dict(
+        zip(aux_params.keys(), aux_names, strict=False)
+    )
 
     # record name mapping of params directly assigned to a component
     name_mapping |= {
@@ -2137,7 +2143,7 @@ def get_model_info(
     # record the LaTeX format of aux parameters
     aux_latex = [params_info[pid].latex for pid in aux_params]
     aux_latex = build_namespace(aux_latex, latex=True, prime=True)['namespace']
-    latex_mapping = dict(zip(aux_params.keys(), aux_latex))
+    latex_mapping = dict(zip(aux_params.keys(), aux_latex, strict=False))
 
     # record the LaTeX format of component parameters from _config
     latex_mapping |= {

--- a/src/elisa/models/parameter.py
+++ b/src/elisa/models/parameter.py
@@ -14,8 +14,8 @@ from elisa.util.integrate import AdaptQuadMethod, make_integral_factory
 from elisa.util.misc import build_namespace
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
-    from typing import Any, Callable, Literal
+    from collections.abc import Callable, Iterable
+    from typing import Any, Literal
 
     # from tinygp import kernels, means, noise
     from elisa.util.integrate import IntegralFactory
@@ -911,6 +911,7 @@ class CompositeParameter(Parameter):
                 build_namespace([p.name for p in self._nodes], prime=True)[
                     'namespace'
                 ],
+                strict=False,
             )
         )
         self._name = self._id_to_label(pid_to_pname, 'name')
@@ -1016,7 +1017,7 @@ class CompositeParameter(Parameter):
     def latex(self) -> str:
         nodes_latex = [p.latex for p in self._nodes]
         latex = build_namespace(nodes_latex, True, True)['namespace']
-        pid_to_latex = dict(zip(self._nodes_id, latex))
+        pid_to_latex = dict(zip(self._nodes_id, latex, strict=False))
         return self._id_to_label(pid_to_latex, 'latex')
 
     @property

--- a/src/elisa/models/parameter.py
+++ b/src/elisa/models/parameter.py
@@ -855,7 +855,7 @@ class CompositeParameter(Parameter):
         op_symbol: Literal['+', '-', '*', '/', '^'] | None = None,
     ):
         # check if the type of params is parameter or sequence
-        if not isinstance(params, (Parameter, Sequence)):
+        if not isinstance(params, Parameter | Sequence):
             raise TypeError(
                 'parameters must be a Parameter or a sequence of Parameter'
             )

--- a/src/elisa/models/parameter.py
+++ b/src/elisa/models/parameter.py
@@ -911,7 +911,7 @@ class CompositeParameter(Parameter):
                 build_namespace([p.name for p in self._nodes], prime=True)[
                     'namespace'
                 ],
-                strict=False,
+                strict=True,
             )
         )
         self._name = self._id_to_label(pid_to_pname, 'name')
@@ -1017,7 +1017,7 @@ class CompositeParameter(Parameter):
     def latex(self) -> str:
         nodes_latex = [p.latex for p in self._nodes]
         latex = build_namespace(nodes_latex, True, True)['namespace']
-        pid_to_latex = dict(zip(self._nodes_id, latex, strict=False))
+        pid_to_latex = dict(zip(self._nodes_id, latex, strict=True))
         return self._id_to_label(pid_to_latex, 'latex')
 
     @property

--- a/src/elisa/models/tables/generate_xsect_table.py
+++ b/src/elisa/models/tables/generate_xsect_table.py
@@ -38,7 +38,7 @@ def get_cross_sections(
     inv_sigma = 1.0 / sigma_
     sigma = np.empty(energy.size)
     for i, e, inv_sigma_e in zip(
-        range(energy.size), egrid, inv_sigma, strict=False
+        range(energy.size), egrid, inv_sigma, strict=True
     ):
         callModelFunction(model, e.tolist(), [inv_sigma_e], m := [])
         sigma[i] = -np.log(m[0]) * sigma_[i]
@@ -54,7 +54,7 @@ def get_wabs_cross_sections(energy: np.ndarray) -> np.ndarray:
     inv_sigma = 1.0 / sigma_
     sigma = np.empty(energy.size)
     for i, e, inv_sigma_e in zip(
-        range(energy.size), egrid, inv_sigma, strict=False
+        range(energy.size), egrid, inv_sigma, strict=True
     ):
         callModelFunction('wabs', e.tolist(), [inv_sigma_e], m := [])
         sigma[i] = -np.log(m[0]) * sigma_[i]

--- a/src/elisa/models/tables/generate_xsect_table.py
+++ b/src/elisa/models/tables/generate_xsect_table.py
@@ -37,7 +37,9 @@ def get_cross_sections(
     sigma_ = np.array(-1000.0 * np.log(abs_model[::2]))
     inv_sigma = 1.0 / sigma_
     sigma = np.empty(energy.size)
-    for i, e, inv_sigma_e in zip(range(energy.size), egrid, inv_sigma):
+    for i, e, inv_sigma_e in zip(
+        range(energy.size), egrid, inv_sigma, strict=False
+    ):
         callModelFunction(model, e.tolist(), [inv_sigma_e], m := [])
         sigma[i] = -np.log(m[0]) * sigma_[i]
     return sigma
@@ -51,7 +53,9 @@ def get_wabs_cross_sections(energy: np.ndarray) -> np.ndarray:
     sigma_ = np.array(-1000.0 * np.log(abs_model[::2]))
     inv_sigma = 1.0 / sigma_
     sigma = np.empty(energy.size)
-    for i, e, inv_sigma_e in zip(range(energy.size), egrid, inv_sigma):
+    for i, e, inv_sigma_e in zip(
+        range(energy.size), egrid, inv_sigma, strict=False
+    ):
         callModelFunction('wabs', e.tolist(), [inv_sigma_e], m := [])
         sigma[i] = -np.log(m[0]) * sigma_[i]
     return sigma

--- a/src/elisa/plot/data.py
+++ b/src/elisa/plot/data.py
@@ -28,8 +28,8 @@ from elisa.plot.residuals import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-    from typing import Any, Callable, Literal
+    from collections.abc import Callable, Sequence
+    from typing import Any, Literal
 
     from xarray import DataArray
 

--- a/src/elisa/plot/misc.py
+++ b/src/elisa/plot/misc.py
@@ -108,7 +108,7 @@ def plot_corner(
     quantile = {p: quantile[p].values.tolist() for p in params}
     titles = [
         f'{t} = {report_interval(median[p], *quantile[p])}'
-        for t, p in zip(titles, params, strict=False)
+        for t, p in zip(titles, params, strict=True)
     ]
 
     if levels is None:

--- a/src/elisa/plot/misc.py
+++ b/src/elisa/plot/misc.py
@@ -108,7 +108,7 @@ def plot_corner(
     quantile = {p: quantile[p].values.tolist() for p in params}
     titles = [
         f'{t} = {report_interval(median[p], *quantile[p])}'
-        for t, p in zip(titles, params)
+        for t, p in zip(titles, params, strict=False)
     ]
 
     if levels is None:

--- a/src/elisa/plot/plotter.py
+++ b/src/elisa/plot/plotter.py
@@ -428,7 +428,7 @@ class Plotter(ABC):
         self.data = self.get_plot_data(result)
         self.config = config
         markers = get_markers(len(self.data))
-        self._markers = dict(zip(self.data.keys(), markers))
+        self._markers = dict(zip(self.data.keys(), markers, strict=False))
 
     @abstractmethod
     def __call__(self, plots: str = 'data ne r') -> dict[str, Figure]:
@@ -464,7 +464,7 @@ class Plotter(ABC):
         """Plotting color for each data."""
         if self._palette != self.config.palette:
             colors = get_colors(len(self.data), palette=self.config.palette)
-            self._colors = dict(zip(self.data.keys(), colors))
+            self._colors = dict(zip(self.data.keys(), colors, strict=False))
             self._palette = self.config.palette
         return self._colors
 
@@ -627,7 +627,7 @@ class Plotter(ABC):
         else:
             residuals = None
 
-        axs_dict = dict(zip(plots, axs))
+        axs_dict = dict(zip(plots, axs, strict=False))
 
         yscale = config.yscale
 
@@ -1060,7 +1060,7 @@ class Plotter(ABC):
         axs = [ax1] + axs.ravel().tolist()
         names = ['total'] + list(self.ndata.keys())
         colors = ['k'] + get_colors(n_subplots, config.palette)
-        for ax, name, color in zip(axs, names, colors):
+        for ax, name, color in zip(axs, names, colors, strict=False):
             theor, q, line, lo, up = _get_qq(
                 r[name], detrend, 0.95, rsim[name]
             )
@@ -1126,7 +1126,7 @@ class Plotter(ABC):
         names = ['total'] + list(self.ndata.keys())
         colors = ['k'] + get_colors(n_subplots, config.palette)
 
-        for ax, name, color in zip(axs, names, colors):
+        for ax, name, color in zip(axs, names, colors, strict=False):
             x, y, line, lower, upper = _get_pit_ecdf(pit[name], 0.95, detrend)
             ax.plot(x, line, ls='--', color=color, alpha=alpha)
             ax.fill_between(
@@ -1200,7 +1200,7 @@ class Plotter(ABC):
         names = ['total'] + list(self.ndata.keys())
         colors = ['k'] + get_colors(n_subplots, config.palette)
 
-        for ax, name, color in zip(axs, names, colors):
+        for ax, name, color in zip(axs, names, colors, strict=False):
             d_obs = dev_obs[name]
             d_sim = np.sort(dev_sim[name])
             sf = 1.0 - np.arange(1.0, n + 1.0) / n
@@ -1339,7 +1339,7 @@ class MLEResultPlotter(Plotter):
         )
         data = {
             name: MLEPlotData(name, result, int(key[0]))
-            for name, key in zip(helper.data_names, keys)
+            for name, key in zip(helper.data_names, keys, strict=False)
         }
         return data
 
@@ -1526,7 +1526,7 @@ class PosteriorResultPlotter(Plotter):
         )
         data = {
             name: PosteriorPlotData(name, result, int(key[0]))
-            for name, key in zip(helper.data_names, keys)
+            for name, key in zip(helper.data_names, keys, strict=False)
         }
         return data
 

--- a/src/elisa/plot/plotter.py
+++ b/src/elisa/plot/plotter.py
@@ -464,7 +464,7 @@ class Plotter(ABC):
         """Plotting color for each data."""
         if self._palette != self.config.palette:
             colors = get_colors(len(self.data), palette=self.config.palette)
-            self._colors = dict(zip(self.data.keys(), colors, strict=False))
+            self._colors = dict(zip(self.data.keys(), colors, strict=True))
             self._palette = self.config.palette
         return self._colors
 

--- a/src/elisa/plot/plotter.py
+++ b/src/elisa/plot/plotter.py
@@ -1057,7 +1057,7 @@ class Plotter(ABC):
         ha = 'center' if detrend else 'left'
         text_x = 0.5 if detrend else 0.03
 
-        axs = [ax1] + axs.ravel().tolist()
+        axs = [ax1] + axs.ravel().tolist()[: len(self.data)]
         names = ['total'] + list(self.ndata.keys())
         colors = ['k'] + get_colors(n_subplots, config.palette)
         for ax, name, color in zip(axs, names, colors, strict=True):
@@ -1122,7 +1122,7 @@ class Plotter(ABC):
         ha = 'right' if detrend else 'left'
         text_x = 0.97 if detrend else 0.03
 
-        axs = [ax1] + axs.ravel().tolist()
+        axs = [ax1] + axs.ravel().tolist()[: len(self.data)]
         names = ['total'] + list(self.ndata.keys())
         colors = ['k'] + get_colors(n_subplots, config.palette)
 
@@ -1196,7 +1196,7 @@ class Plotter(ABC):
         ax1.set_xlabel('$D$')
         ax1.set_ylabel(r'$P(\mathcal{D} \geq D)$')
 
-        axs = [ax1] + axs.ravel().tolist()
+        axs = [ax1] + axs.ravel().tolist()[: len(self.data)]
         names = ['total'] + list(self.ndata.keys())
         colors = ['k'] + get_colors(n_subplots, config.palette)
 

--- a/src/elisa/plot/plotter.py
+++ b/src/elisa/plot/plotter.py
@@ -1058,7 +1058,7 @@ class Plotter(ABC):
         text_x = 0.5 if detrend else 0.03
 
         axs = [ax1] + axs.ravel().tolist()[: len(self.data)]
-        names = ['total'] + list(self.ndata.keys())
+        names = ['total'] + list(self.data.keys())
         colors = ['k'] + get_colors(n_subplots, config.palette)
         for ax, name, color in zip(axs, names, colors, strict=True):
             theor, q, line, lo, up = _get_qq(
@@ -1123,7 +1123,7 @@ class Plotter(ABC):
         text_x = 0.97 if detrend else 0.03
 
         axs = [ax1] + axs.ravel().tolist()[: len(self.data)]
-        names = ['total'] + list(self.ndata.keys())
+        names = ['total'] + list(self.data.keys())
         colors = ['k'] + get_colors(n_subplots, config.palette)
 
         for ax, name, color in zip(axs, names, colors, strict=True):
@@ -1197,7 +1197,7 @@ class Plotter(ABC):
         ax1.set_ylabel(r'$P(\mathcal{D} \geq D)$')
 
         axs = [ax1] + axs.ravel().tolist()[: len(self.data)]
-        names = ['total'] + list(self.ndata.keys())
+        names = ['total'] + list(self.data.keys())
         colors = ['k'] + get_colors(n_subplots, config.palette)
 
         for ax, name, color in zip(axs, names, colors, strict=True):

--- a/src/elisa/plot/plotter.py
+++ b/src/elisa/plot/plotter.py
@@ -428,7 +428,7 @@ class Plotter(ABC):
         self.data = self.get_plot_data(result)
         self.config = config
         markers = get_markers(len(self.data))
-        self._markers = dict(zip(self.data.keys(), markers, strict=False))
+        self._markers = dict(zip(self.data.keys(), markers, strict=True))
 
     @abstractmethod
     def __call__(self, plots: str = 'data ne r') -> dict[str, Figure]:
@@ -627,7 +627,7 @@ class Plotter(ABC):
         else:
             residuals = None
 
-        axs_dict = dict(zip(plots, axs, strict=False))
+        axs_dict = dict(zip(plots, axs, strict=True))
 
         yscale = config.yscale
 
@@ -1060,7 +1060,7 @@ class Plotter(ABC):
         axs = [ax1] + axs.ravel().tolist()
         names = ['total'] + list(self.ndata.keys())
         colors = ['k'] + get_colors(n_subplots, config.palette)
-        for ax, name, color in zip(axs, names, colors, strict=False):
+        for ax, name, color in zip(axs, names, colors, strict=True):
             theor, q, line, lo, up = _get_qq(
                 r[name], detrend, 0.95, rsim[name]
             )
@@ -1126,7 +1126,7 @@ class Plotter(ABC):
         names = ['total'] + list(self.ndata.keys())
         colors = ['k'] + get_colors(n_subplots, config.palette)
 
-        for ax, name, color in zip(axs, names, colors, strict=False):
+        for ax, name, color in zip(axs, names, colors, strict=True):
             x, y, line, lower, upper = _get_pit_ecdf(pit[name], 0.95, detrend)
             ax.plot(x, line, ls='--', color=color, alpha=alpha)
             ax.fill_between(
@@ -1200,7 +1200,7 @@ class Plotter(ABC):
         names = ['total'] + list(self.ndata.keys())
         colors = ['k'] + get_colors(n_subplots, config.palette)
 
-        for ax, name, color in zip(axs, names, colors, strict=False):
+        for ax, name, color in zip(axs, names, colors, strict=True):
             d_obs = dev_obs[name]
             d_sim = np.sort(dev_sim[name])
             sf = 1.0 - np.arange(1.0, n + 1.0) / n
@@ -1339,7 +1339,7 @@ class MLEResultPlotter(Plotter):
         )
         data = {
             name: MLEPlotData(name, result, int(key[0]))
-            for name, key in zip(helper.data_names, keys, strict=False)
+            for name, key in zip(helper.data_names, keys, strict=True)
         }
         return data
 
@@ -1526,7 +1526,7 @@ class PosteriorResultPlotter(Plotter):
         )
         data = {
             name: PosteriorPlotData(name, result, int(key[0]))
-            for name, key in zip(helper.data_names, keys, strict=False)
+            for name, key in zip(helper.data_names, keys, strict=True)
         }
         return data
 

--- a/src/elisa/plot/residuals.py
+++ b/src/elisa/plot/residuals.py
@@ -14,7 +14,7 @@ def combine_residuals(
     dof: int | float | NDArray,
     sign: NDArray | None = None,
 ) -> NDArray:
-    if isinstance(dof, (float, int)):
+    if isinstance(dof, float | int):
         dof = float(dof)
     else:
         dof = np.asarray(dof, float)
@@ -464,7 +464,7 @@ def deviance_residuals_poisson_poisson(
     if np.all(dof == 1.0):
         r = np.sqrt(d)
     else:
-        if isinstance(dof, (float, int)):
+        if isinstance(dof, float | int):
             dof = np.full(k1.shape, dof)
 
         mask = d <= dof
@@ -523,7 +523,7 @@ def deviance_residuals_poisson_normal(
     if np.all(dof == 1.0):
         r = np.sqrt(d)
     else:
-        if isinstance(dof, (float, int)):
+        if isinstance(dof, float | int):
             dof = np.full(k.shape, dof)
 
         mask = d <= dof

--- a/src/elisa/plot/util.py
+++ b/src/elisa/plot/util.py
@@ -21,7 +21,9 @@ def get_colors(
 
 def get_markers(n: int) -> list[str]:
     markers_cycle = cycle(['s', 'o', 'D', '^', 'd', 'p', 'h', 'H', 'D'])
-    return [marker for marker, _ in zip(markers_cycle, range(int(n)))]
+    return [
+        marker for marker, _ in zip(markers_cycle, range(int(n)), strict=False)
+    ]
 
 
 def _clip(num):

--- a/src/elisa/util/integrate.py
+++ b/src/elisa/util/integrate.py
@@ -26,7 +26,7 @@ _QUAD_FN = dict(
     zip(
         get_args(AdaptQuadMethod),
         [quadgk, quadcc, quadts, romberg, rombergts],
-        strict=False,
+        strict=True,
     )
 )
 

--- a/src/elisa/util/integrate.py
+++ b/src/elisa/util/integrate.py
@@ -8,7 +8,8 @@ import jax.numpy as jnp
 from quadax import quadcc, quadgk, quadts, romberg, rombergts
 
 if TYPE_CHECKING:
-    from typing import Any, Callable
+    from collections.abc import Callable
+    from typing import Any
 
     from elisa.util.typing import (
         JAXArray,
@@ -23,7 +24,9 @@ if TYPE_CHECKING:
 AdaptQuadMethod = Literal['quadgk', 'quadcc', 'quadts', 'romberg', 'rombergts']
 _QUAD_FN = dict(
     zip(
-        get_args(AdaptQuadMethod), [quadgk, quadcc, quadts, romberg, rombergts]
+        get_args(AdaptQuadMethod),
+        [quadgk, quadcc, quadts, romberg, rombergts],
+        strict=False,
     )
 )
 

--- a/src/elisa/util/misc.py
+++ b/src/elisa/util/misc.py
@@ -32,14 +32,14 @@ UNICODE_SUBSCRIPT = dict(
     zip(
         'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-/=()',
         'ᴀʙᴄᴅᴇғɢʜɪᴊᴋʟᴍɴᴏᴘǫʀsᴛᴜᴠᴡxʏᴢₐᵦ𝒸𝒹ₑ𝒻𝓰ₕᵢⱼₖₗₘₙₒₚᵩᵣₛₜᵤᵥ𝓌ₓᵧ𝓏₀₁₂₃₄₅₆₇₈₉₊₋⸝₌₍₎',
-        strict=False,
+        strict=True,
     )
 )
 UNICODE_SUPERSCRIPT = dict(
     zip(
         'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-/=()',
         'ᴬᴮᶜᴰᴱᶠᴳᴴᴵᴶᴷᴸᴹᴺᴼᴾᵠᴿˢᵀᵁⱽᵂᕽʸᶻᵃᵇᶜᵈᵉᶠᵍʰⁱʲᵏˡᵐⁿᵒᵖᵠʳˢᵗᵘᵛʷˣʸᶻ⁰¹²³⁴⁵⁶⁷⁸⁹⁺⁻ᐟ⁼⁽⁾',
-        strict=False,
+        strict=True,
     )
 )
 UNICODE_SUFFIX = False
@@ -177,7 +177,7 @@ def add_suffix(
 
     strings = [
         i + template % j if j else i
-        for i, j in zip(strings, suffix, strict=False)
+        for i, j in zip(strings, suffix, strict=True)
     ]
 
     if return_list:
@@ -229,7 +229,7 @@ def build_namespace(
         suffixes = [template % n if n > 1 else '' for n in suffixes_n]
 
     return {
-        'namespace': list(map(''.join, zip(names, suffixes, strict=False))),
+        'namespace': list(map(''.join, zip(names, suffixes, strict=True))),
         'suffix_num': [str(n) if n > 1 else '' for n in suffixes_n],
     }
 
@@ -343,7 +343,7 @@ def get_unit_latex(unit: str, throw: bool = True) -> str:
             powers = [unit.powers[i] for i in index]
             ustr = r'\ '.join(
                 b + (f'^{{{p}}}' if p != 1 else '')
-                for b, p in zip(bases, powers, strict=False)
+                for b, p in zip(bases, powers, strict=True)
             )
             scale = Unit(unit.scale).to_string('latex_inline')[9:-2]
             if scale != '':
@@ -429,7 +429,7 @@ def replace_string(value: T, mapping: dict[str, str]) -> T:
         """The main replace function."""
         if isinstance(v, str):
             return replace_with_mapping(v)
-        elif isinstance(v, (list, tuple)):
+        elif isinstance(v, list | tuple):
             return replace_sequence(v)
         elif isinstance(v, dict):
             return replace_dict(v)

--- a/src/elisa/util/misc.py
+++ b/src/elisa/util/misc.py
@@ -19,8 +19,8 @@ from prettytable import PrettyTable
 from tqdm.auto import tqdm
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-    from typing import Callable, Literal, TypeVar
+    from collections.abc import Callable, Sequence
+    from typing import Literal, TypeVar
 
     from numpy import ndarray as NDArray
 
@@ -32,12 +32,14 @@ UNICODE_SUBSCRIPT = dict(
     zip(
         'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-/=()',
         'ᴀʙᴄᴅᴇғɢʜɪᴊᴋʟᴍɴᴏᴘǫʀsᴛᴜᴠᴡxʏᴢₐᵦ𝒸𝒹ₑ𝒻𝓰ₕᵢⱼₖₗₘₙₒₚᵩᵣₛₜᵤᵥ𝓌ₓᵧ𝓏₀₁₂₃₄₅₆₇₈₉₊₋⸝₌₍₎',
+        strict=False,
     )
 )
 UNICODE_SUPERSCRIPT = dict(
     zip(
         'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-/=()',
         'ᴬᴮᶜᴰᴱᶠᴳᴴᴵᴶᴷᴸᴹᴺᴼᴾᵠᴿˢᵀᵁⱽᵂᕽʸᶻᵃᵇᶜᵈᵉᶠᵍʰⁱʲᵏˡᵐⁿᵒᵖᵠʳˢᵗᵘᵛʷˣʸᶻ⁰¹²³⁴⁵⁶⁷⁸⁹⁺⁻ᐟ⁼⁽⁾',
+        strict=False,
     )
 )
 UNICODE_SUFFIX = False
@@ -173,7 +175,10 @@ def add_suffix(
         else:
             template = PLAIN_SUPERSCRIPT_TEMPLATE
 
-    strings = [i + template % j if j else i for i, j in zip(strings, suffix)]
+    strings = [
+        i + template % j if j else i
+        for i, j in zip(strings, suffix, strict=False)
+    ]
 
     if return_list:
         return strings
@@ -224,7 +229,7 @@ def build_namespace(
         suffixes = [template % n if n > 1 else '' for n in suffixes_n]
 
     return {
-        'namespace': list(map(''.join, zip(names, suffixes))),
+        'namespace': list(map(''.join, zip(names, suffixes, strict=False))),
         'suffix_num': [str(n) if n > 1 else '' for n in suffixes_n],
     }
 
@@ -338,7 +343,7 @@ def get_unit_latex(unit: str, throw: bool = True) -> str:
             powers = [unit.powers[i] for i in index]
             ustr = r'\ '.join(
                 b + (f'^{{{p}}}' if p != 1 else '')
-                for b, p in zip(bases, powers)
+                for b, p in zip(bases, powers, strict=False)
             )
             scale = Unit(unit.scale).to_string('latex_inline')[9:-2]
             if scale != '':

--- a/src/elisa/util/typing.py
+++ b/src/elisa/util/typing.py
@@ -1,6 +1,7 @@
 """Typing aliases to shorten hints."""
 
-from typing import Callable, TypeVar, Union
+from collections.abc import Callable
+from typing import TypeVar, Union
 
 import numpy as np
 from jax import Array

--- a/src/elisa/util/typing.py
+++ b/src/elisa/util/typing.py
@@ -1,7 +1,7 @@
 """Typing aliases to shorten hints."""
 
 from collections.abc import Callable
-from typing import TypeVar, Union
+from typing import TypeVar
 
 import numpy as np
 from jax import Array
@@ -37,15 +37,15 @@ __all__ = [
 
 T = TypeVar('T')
 
-PyFloat = Union[float, np.inexact]  # must include 0-d NDArray with float dtype
+PyFloat = float | np.inexact  # must include 0-d NDArray with float dtype
 JAXFloat = Array
-Float = Union[PyFloat, JAXFloat]
+Float = PyFloat | JAXFloat
 
 PRNGKey = Array
 
 NumPyArray = np.ndarray
 JAXArray = Array
-Array = Union[NumPyArray, JAXArray]
+Array = NumPyArray | JAXArray
 
 ArrayLike = ArrayLike
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from elisa.infer.fit import BayesFit, MaxLikeFit
 from elisa.models.add import PowerLaw
 
 if TYPE_CHECKING:
-    from typing import Callable
+    from collections.abc import Callable
 
     from elisa import Data
     from elisa.infer.results import MLEResult, PosteriorResult

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -69,7 +69,7 @@ def test_mle_covar(
     covar_true = mle_result2_covar[1](
         params_mle,
         lambda x: flux(
-            dict(zip(['PowerLaw.alpha', 'PowerLaw.K'], x, strict=False))
+            dict(zip(['PowerLaw.alpha', 'PowerLaw.K'], x, strict=True))
         ),
     )
 
@@ -247,7 +247,7 @@ def test_posterior_covar(
     covar_true = mle_result2_covar[1](
         params_mle,
         lambda x: flux(
-            dict(zip(['PowerLaw.alpha', 'PowerLaw.K'], x, strict=False))
+            dict(zip(['PowerLaw.alpha', 'PowerLaw.K'], x, strict=True))
         ),
     )
 

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -68,7 +68,9 @@ def test_mle_covar(
 
     covar_true = mle_result2_covar[1](
         params_mle,
-        lambda x: flux(dict(zip(['PowerLaw.alpha', 'PowerLaw.K'], x))),
+        lambda x: flux(
+            dict(zip(['PowerLaw.alpha', 'PowerLaw.K'], x, strict=False))
+        ),
     )
 
     covar = mle_result2.covar(fn={'flux': flux}, method=method).matrix
@@ -244,7 +246,9 @@ def test_posterior_covar(
 
     covar_true = mle_result2_covar[1](
         params_mle,
-        lambda x: flux(dict(zip(['PowerLaw.alpha', 'PowerLaw.K'], x))),
+        lambda x: flux(
+            dict(zip(['PowerLaw.alpha', 'PowerLaw.K'], x, strict=False))
+        ),
     )
 
     covar = result.covar(fn={'flux': flux}).matrix


### PR DESCRIPTION
## Summary by Sourcery

Update project configuration for linting, testing, and code coverage

Enhancements:
- Bump Ruff linter target version from Python 3.9 to 3.10
- Adjust Pytest addopts to use generic coverage flags
- Enable coverage reporting concurrency with threads and multiprocessing
- Restrict coverage to source files with relative paths
- Enable showing missing lines in coverage reports