### PR TITLE
chore: update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
           flags: "py${{ matrix.python-version }}"
           name: "Python ${{ matrix.python-version }}"
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          verbose: true
 
       - name: Upload Coverage Results
         uses: codecov/codecov-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,15 @@ jobs:
         run: |
           pytest
 
+      - name: Upload Test Results
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          file: junit.xml
+          flags: "py${{ matrix.python-version }}"
+          name: "Python ${{ matrix.python-version }}"
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Upload Coverage Results
         uses: codecov/codecov-action@v5
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ lint.select = [
 "docs/notebooks/model-building.ipynb" = ["F403", "F405"]
 
 [tool.pytest]
-ini_options.addopts = "-n auto --cov --cov-report xml"
+ini_options.addopts = "-n auto --cov --cov-report=xml --junitxml=junit.xml"
 ini_options.testpaths = ["tests"]
 
 [tool.coverage]


### PR DESCRIPTION
## Summary by Sourcery

Enable JUnit test reporting and upload results to Codecov in the CI workflow

CI:
- Add 'Upload Test Results' step using codecov/test-results-action@v1 to CI
- Pass JUnit XML file, Python version flags, and Codecov token to test results action

Tests:
- Update pytest addopts to generate a JUnit XML report alongside coverage output