### PR TITLE
feat: rebin data with existing grouping flags preserved

### DIFF
--- a/src/elisa/data/base.py
+++ b/src/elisa/data/base.py
@@ -481,9 +481,9 @@ class ObservationData:
             )
 
         # Group the channel segaments derived from user-specified erange,
-        # e.g., for erange=[(0.1, 10), (20, 30)], there are two segments.
+        # e.g., for erange=[(0.1, 10), (20, 30)], there are two segaments.
         # Here, the number of channel_mask's rows is equal to the number
-        # of the segments.
+        # of the segaments.
         results = list(map(fn, zip(*data, strict=True)))
         grouping = np.hstack([r[0] for r in results])
         success = all(r[1] for r in results)

--- a/src/elisa/data/ogip.py
+++ b/src/elisa/data/ogip.py
@@ -67,6 +67,13 @@ class Data(ObservationData):
         The default is None.
     scale : float or None, optional
         Grouping scale for the method specified in `group`.
+    preserve_data_group : bool, optional
+        Whether to preserve the grouping flags stored in `specfile`.
+        If true, will first group the data based on the grouping flags stored
+        in `specfile`, then apply the grouping method specified in `group`.
+        If false, will directly apply the grouping method specified in
+        `group` to the data, ignoring the grouping flags stored in `specfile`.
+        The default is False.
     spec_poisson : bool or None, optional
         Whether the spectrum data follows counting statistics, reading from
         the `specfile` header. This value must be set if ``POISSERR`` is
@@ -116,6 +123,7 @@ class Data(ObservationData):
         name: str | None = None,
         group: str | None = None,
         scale: float | None = None,
+        preserve_data_group: bool = False,
         spec_poisson: bool | None = None,
         back_poisson: bool | None = None,
         ignore_bad: bool = True,
@@ -198,7 +206,7 @@ class Data(ObservationData):
         )
 
         if group is not None:
-            self.group(group, scale)
+            self.group(group, scale, preserve_data_group)
 
 
 class Spectrum(SpectrumData):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -66,8 +66,9 @@ def test_data_grouping(erange):
     if erange is not None:
         data.set_erange(erange)
 
-    scale = 6
     nchan = data.channel.size
+
+    scale = 6
     data.group('const', scale)
     assert data.channel.size == nchan // scale
 
@@ -92,7 +93,7 @@ def test_data_grouping(erange):
     assert np.all(sig >= scale)
 
     data.group('opt')
-    assert data.channel.size == nbins
+    assert data.channel.size == nchan
 
     scale = 1
     data.group('optmin', scale)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -67,8 +67,9 @@ def test_data_grouping(erange):
         data.set_erange(erange)
 
     scale = 6
+    nchan = data.channel.size
     data.group('const', scale)
-    assert data.channel.size == nbins // scale
+    assert data.channel.size == nchan // scale
 
     scale = 1
     data.group('min', scale)
@@ -121,6 +122,9 @@ def test_data_grouping(erange):
     data.group('const', scale, preserve_data_group=True)
     assert data.channel.size == original_nchan // scale
     assert np.all(data.grouping[original_grouping == -1] == -1)
+
+    with pytest.raises(ValueError):
+        data.group('optbsig', scale, preserve_data_group=True)
 
     data = compiled_model.simulate(
         photon_egrid=photon_egrid,


### PR DESCRIPTION
## Summary by Sourcery

Enable rebinned grouping that respects existing group flags by adding a preserve_data_group option, refactoring the grouping pipeline for segment-wise processing and consistency, and introducing helper methods for optimal grouping data and energy grid extraction. Update the OGIP loader and expand tests to validate new behaviors.

New Features:
- Introduce preserve_data_group option in Data(...) and Data.group(...) to rebin while preserving original grouping flags
- Add _counts_data_for_opt_grouping helper to supply data for optimal grouping
- Expose group_energy method to extract grouped energy grid and channel info

Enhancements:
- Refactor set_grouping and group methods to perform segment-wise grouping, filter out groups without good channels, and warn/reset invalid first flag
- Restore original grouping flags when calling Data.set_grouping(None) and streamline grouping masks based on energy ranges
- Simplify internal grouping loops by mapping per-segment functions and reconstructing final grouping array

Tests:
- Parameterize data plotting and grouping tests over multiple energy range scenarios
- Add tests for preserve_data_group behavior and warning on invalid first grouping flag
- Extend plot_spec, plot_matrix, and plot_effective_area tests to exercise different log and hatch options