### PR TITLE
feat: storage of `emcee` sampler state

### DIFF
--- a/src/elisa/infer/samplers/ensemble/emcee.py
+++ b/src/elisa/infer/samplers/ensemble/emcee.py
@@ -98,11 +98,12 @@ class EmceeSampler:
             chains = 4 * ndim
 
         if states is None:
-            rng = np.random.default_rng(self._seed)
+            seeds = np.random.SeedSequence(self._seed).spawn(n_parallel + 1)
+            rng = np.random.default_rng(seeds[0])
             init = np.full((chains, ndim), self._init)
             jitter = rng.uniform(0.99, 1.01, size=(n_parallel, chains, ndim))
             init = init * jitter
-            rngs = rng.spawn(n_parallel)
+            rngs = list(map(np.random.default_rng, seeds[1:]))
             states = [
                 State(i, random_state=j)
                 for i, j in zip(init, rngs, strict=True)

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -81,8 +81,14 @@ def test_trivial_bayes_fit(simulation, method, options):
         model['PowerLaw']['alpha'].default = 0.0
         model['PowerLaw']['K'].default = 10.0
 
-    # Get Bayesian fit result, i.e. posterior
-    result = getattr(BayesFit(data, model, seed=100), method)(**options)
+    fit_fn = getattr(BayesFit(data, model, seed=100), method)
+
+    # Bayesian fit result, i.e. posterior
+    result = fit_fn(**options)
+
+    # test refit with given post_warmup_state
+    if result.sampler_state is not None:
+        fit_fn(steps=100, post_warmup_state=result.sampler_state, **options)
 
     # check convergence
     assert all(i < 1.01 for i in result.rhat.values() if not np.isnan(i))


### PR DESCRIPTION
## Summary by Sourcery

Enable storing, returning, and reusing emcee sampler states to support seamless warm-up resumption and refitting

New Features:
- Add support for passing initial emcee sampler states to resume sampling
- Return final sampler State objects from the emcee runner
- Introduce a `post_warmup_state` argument in `fit.emcee` to resume sampling from a previous state

Enhancements:
- Refactor `run` to handle `State` objects, validate provided states, and disable warmup when reusing states
- Adjust worker function to accept and return `State` instances instead of separate initialization and RNG
- Update progress bar management to initialize after warmup computation

Tests:
- Add test to verify refitting with the returned `sampler_state`