### PR TITLE
feat: add ensemble slice sampler of `zeus`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "tinygp==0.3.0",
     "tqdm>=4.66.0",
     "ultranest==4.4.0",
+    "zeus-mcmc==2.5.4",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,8 @@ run.concurrency = [
     "thread",
     "multiprocessing",
 ]
+run.parallel = true
+sigterm = true
 run.source_dirs = ["src"]
 run.omit = [
     "src/elisa/infer/samplers/ns/jaxns.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ run.concurrency = [
     "multiprocessing",
 ]
 run.parallel = true
-sigterm = true
+run.sigterm = true
 run.source_dirs = ["src"]
 run.omit = [
     "src/elisa/infer/samplers/ns/jaxns.py",

--- a/src/elisa/infer/samplers/ensemble/base.py
+++ b/src/elisa/infer/samplers/ensemble/base.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import threading
+import warnings
+from abc import ABCMeta, abstractmethod
+from typing import TYPE_CHECKING, NamedTuple
+
+import jax
+import jax.numpy as jnp
+import multiprocess as mp
+import numpy as np
+from numpyro.infer.initialization import init_to_value
+from tqdm.auto import tqdm
+
+from elisa.infer.samplers.util import get_model_info
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+    from multiprocessing import Queue
+    from typing import Any
+
+    from numpy.typing import NDArray
+
+
+class EnsembleSamplerState(NamedTuple):
+    """Ensemble sampler state."""
+
+    coords: NDArray[float]
+    """The current positions of the walkers in the parameter space."""
+
+    random_state: Any
+    """The state of random number generator."""
+
+
+class EnsembleSampler(metaclass=ABCMeta):
+    def __init__(
+        self,
+        numpyro_model: Callable,
+        init_params: dict[str, float] | None = None,
+        ignore_nan: bool = False,
+        seed: int = 42,
+        model_args: tuple = (),
+        model_kwargs: dict | None = None,
+    ):
+        """The base class for ensemble samplers.
+
+        Parameters
+        ----------
+        numpyro_model : callable
+            The numpyro model to sample from.
+        init_params : dict, optional
+            The initial parameters for the model.
+        ignore_nan : bool, optional
+            Whether to transform log probability of NaN to -1e300.
+            The default is False.
+        seed : int, optional
+            The random seed for reproducibility.
+        model_args : tuple, optional
+            The arguments to pass to `numpyro_model`.
+        model_kwargs : dict, optional
+            The keyword arguments to pass to `numpyro_model`.
+        """
+        if ignore_nan:
+            warnings.warn(
+                'setting `ignore_nan` to True may fail to spot potential '
+                'issues of the model',
+                Warning,
+            )
+
+        if init_params is None:
+            init_params = {}
+
+        info = get_model_info(
+            model=numpyro_model,
+            init_strategy=init_to_value(values=init_params),
+            model_args=model_args,
+            model_kwargs=model_kwargs,
+            validate_grad=False,
+            rng_seed=seed,
+        )
+
+        ndim = info.ndim
+        blobs_dtype = info.params_dtype + info.deterministic_dtype
+        blobs_names = [dt[0] for dt in blobs_dtype]
+        init = info.init_ravel
+        unravel = info.unravel
+        log_prob_fn = info.log_prob_fn
+        postprocess_fn = info.postprocess_fn
+
+        @jax.vmap
+        @jax.jit
+        def _log_prob_with_blobs(z):
+            z = unravel(z)
+            log_prob = log_prob_fn(z)
+            blobs = postprocess_fn(z)
+            return log_prob, [blobs[i] for i in blobs_names]
+
+        @jax.jit
+        def log_prob_with_blobs(z):
+            log_prob, blobs = _log_prob_with_blobs(z)
+            if ignore_nan:
+                log_prob = jnp.nan_to_num(log_prob, nan=-np.inf)
+            return [
+                (log_prob[i], *(b[i] for b in blobs))
+                for i in range(len(log_prob))
+            ]
+
+        self._ndim = ndim
+        self._init = init
+        self._log_prob_with_blobs = log_prob_with_blobs
+        self._blobs_dtype = blobs_dtype
+        self._seed = seed
+
+    def run(
+        self,
+        warmup: int = 5000,
+        steps: int = 5000,
+        chains: int | None = None,
+        thinning: int = 1,
+        n_parallel: int = 4,
+        tune: bool | None = None,
+        progress: bool = True,
+        states: Sequence[EnsembleSamplerState] | None = None,
+        warmup_kwargs: dict | None = None,
+        sampling_kwargs: dict | None = None,
+    ) -> tuple[dict[str, NDArray[float]], tuple[EnsembleSamplerState, ...]]:
+        """Run the sampler.
+
+        Parameters
+        ----------
+        warmup : int, optional
+            The warmup (burn-in) steps. The default is 5000.
+        steps : int, optional
+            The sampling steps. The default is 5000.
+        chains : int, optional
+            The number of walkers. The default is 4 * ndim.
+        thinning : int
+            Stores every `thinning` samples in the chain. When this is set,
+            `steps` * `thinning` proposals will be made. The default is 1.
+        n_parallel : int, optional
+            Number of parallel samplers. The default is 4.
+        tune : bool, optional
+            Whether to tune the parameters of moves.
+            Defaults to the corresponding sampler's default.
+        progress : bool, optional
+            Whether to display a progress bar. The default is True.
+        states : sequence, optional
+            The initial states of the samplers.
+        warmup_kwargs: dict, optional
+            Extra parameters passed to sampler constructor for warm-up phase.
+        sampling_kwargs: dict | None = None,
+            Extra parameters passed to sampler constructor for sampling phase.
+
+        Returns
+        -------
+        samples : dict
+            The posterior samples.
+        states : tuple
+            The states of the samplers.
+        """
+        ndim = self._ndim
+        if chains is None:
+            chains = 4 * ndim
+        if states is None:
+            seed0 = np.random.default_rng(self._seed).integers(2**32)
+            seed_init, *seeds_mcmc = seed0 + np.arange(n_parallel + 1)
+            rng_init = np.random.default_rng(seed_init)
+            jitter = rng_init.uniform(0.9, 1.1, (n_parallel, chains, ndim))
+            init = jitter * np.full((chains, ndim), self._init)
+            states = [
+                EnsembleSamplerState(i, self.get_random_state(j))
+                for i, j in zip(init, seeds_mcmc, strict=True)
+            ]
+        else:
+            states = list(states)
+            if len(states) != n_parallel:
+                raise ValueError('states number should match n_parallel')
+            if not all(isinstance(s, EnsembleSamplerState) for s in states):
+                raise ValueError('states must be EnsembleSamplerState')
+            for s in states:
+                if s.coords.shape != (chains, ndim):
+                    raise ValueError(
+                        f"states' coords must have shape ({chains}, {ndim})"
+                    )
+            warmup = 0
+
+        if warmup_kwargs is None:
+            warmup_kwargs = {}
+        else:
+            warmup_kwargs = dict(warmup_kwargs)
+
+        if sampling_kwargs is None:
+            sampling_kwargs = {}
+        else:
+            sampling_kwargs = dict(sampling_kwargs)
+
+        old_method = mp.get_start_method()
+        if old_method != 'spawn':
+            mp.set_start_method('spawn', force=True)
+        else:
+            old_method = ''
+
+        pbars = {
+            i: tqdm(
+                total=warmup + steps,
+                desc='Initializing... ',
+                position=i,
+                disable=not progress,
+            )
+            for i in range(1, n_parallel + 1)
+        }
+
+        queue = mp.Manager().Queue()
+        listener_thread = threading.Thread(
+            target=self._progress_listener,
+            args=(queue, pbars, n_parallel),
+        )
+        listener_thread.start()
+
+        sampling_fn = self.get_sampling_fn(
+            chains=chains,
+            warmup=warmup,
+            steps=steps,
+            thinning=thinning,
+            tune=tune,
+            warmup_kwargs=warmup_kwargs,
+            sampling_kwargs=sampling_kwargs,
+        )
+
+        with mp.Pool(processes=n_parallel) as pool:
+            results = []
+            for i in range(n_parallel):
+                r = pool.apply_async(
+                    sampling_fn,
+                    args=(i + 1, states[i], queue),
+                )
+                results.append(r)
+            results = [r.get() for r in results]
+
+        listener_thread.join()
+
+        if old_method:
+            mp.set_start_method(old_method, force=True)
+
+        # get samples
+        samples = [r[0] for r in results]
+        # reshape samples from (n_step, n_walker) to (n_walker, n_step)
+        samples = list(map(np.transpose, samples))
+        # merge chains from the same sampler into a single one
+        samples = list(map(np.concatenate, samples))
+        # stack samples of different samplers
+        samples = np.vstack(samples)
+        # make samples a dict
+        samples = {i: samples[i] for i in samples.dtype.names}
+        # get states
+        states = tuple(r[1] for r in results)
+        return samples, states
+
+    @staticmethod
+    def _progress_listener(
+        queue: Queue,
+        pbars: dict[int, tqdm],
+        num_samplers: int,
+    ):
+        finished = 0
+        while finished < num_samplers:
+            sampler_id, msg = queue.get()
+            if msg == 'update':
+                pbars[sampler_id].update(1)
+            elif msg == 'warmup':
+                pbars[sampler_id].set_description(
+                    f'Warm-up sampler {sampler_id}'
+                )
+            elif msg == 'sample':
+                pbars[sampler_id].set_description(
+                    f'Running sampler {sampler_id}',
+                )
+            elif msg == 'finish':
+                pbars[sampler_id].set_description(
+                    f'Finished sampler {sampler_id}',
+                )
+                pbars[sampler_id].close()
+                finished += 1
+
+    @abstractmethod
+    def get_sampling_fn(
+        self,
+        chains: int,
+        warmup: int,
+        steps: int,
+        thinning: int,
+        tune: bool | None,
+        warmup_kwargs: dict,
+        sampling_kwargs: dict,
+    ) -> Callable[
+        [int, EnsembleSamplerState, Queue],
+        tuple[NDArray, EnsembleSamplerState],
+    ]:
+        """Generate the sampling function."""
+        pass
+
+    @abstractmethod
+    def get_random_state(self, seed: int) -> Any:
+        """Get the random state for the sampler."""
+        pass

--- a/src/elisa/infer/samplers/ensemble/emcee.py
+++ b/src/elisa/infer/samplers/ensemble/emcee.py
@@ -1,232 +1,101 @@
 from __future__ import annotations
 
-import threading
-import warnings
 from typing import TYPE_CHECKING
 
-import jax
-import jax.numpy as jnp
-import multiprocess as mp
 import numpy as np
-from emcee import EnsembleSampler, State
-from numpyro.infer.initialization import init_to_value
-from tqdm.auto import tqdm
+from emcee import EnsembleSampler as Sampler, State as EmceeState
 
-from elisa.infer.samplers.util import get_model_info
+from elisa.infer.samplers.ensemble.base import (
+    EnsembleSampler,
+    EnsembleSamplerState,
+)
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from multiprocessing import Queue
 
-    from numpy.typing import NDArray
+    from numpy.random import Generator
 
 
-class EmceeSampler:
-    def __init__(
+class EmceeSampler(EnsembleSampler):
+    def get_sampling_fn(
         self,
-        numpyro_model: Callable,
-        init_params: dict[str, float] | None = None,
-        ignore_nan: bool = False,
-        seed: int = 42,
-        model_args: tuple = (),
-        model_kwargs: dict | None = None,
+        chains: int,
+        warmup: int,
+        steps: int,
+        thinning: int,
+        tune: bool | None,
+        warmup_kwargs: dict,
+        sampling_kwargs: dict,
     ):
-        if ignore_nan:
-            warnings.warn(
-                'setting `ignore_nan` to True may fail to spot potential '
-                'issues of the model',
-                Warning,
-            )
-
-        if init_params is None:
-            init_params = {}
-
-        info = get_model_info(
-            model=numpyro_model,
-            init_strategy=init_to_value(values=init_params),
-            model_args=model_args,
-            model_kwargs=model_kwargs,
-            validate_grad=False,
-            rng_seed=seed,
-        )
-
-        ndim = info.ndim
-        blobs_dtype = info.params_dtype + info.deterministic_dtype
-        blobs_names = [dt[0] for dt in blobs_dtype]
-        init = info.init_ravel
-        unravel = info.unravel
-        log_prob_fn = info.log_prob_fn
-        postprocess_fn = info.postprocess_fn
-
-        @jax.vmap
-        @jax.jit
-        def _log_prob_with_blobs(z):
-            z = unravel(z)
-            log_prob = log_prob_fn(z)
-            blobs = postprocess_fn(z)
-            return log_prob, [blobs[i] for i in blobs_names]
-
-        @jax.jit
-        def log_prob_with_blobs(z):
-            log_prob, blobs = _log_prob_with_blobs(z)
-            if ignore_nan:
-                log_prob = jnp.nan_to_num(log_prob, nan=-np.inf)
-            return [
-                (log_prob[i], *(b[i] for b in blobs))
-                for i in range(len(log_prob))
-            ]
-
-        self._ndim = ndim
-        self._init = init
-        self._log_prob_with_blobs = log_prob_with_blobs
-        self._blobs_dtype = blobs_dtype
-        self._seed = seed
-
-    def run(
-        self,
-        warmup: int = 5000,
-        steps: int = 5000,
-        chains: int | None = None,
-        thinning: int = 1,
-        n_parallel: int = 4,
-        tune: bool = False,
-        progress: bool = True,
-        states: Sequence[State] | None = None,
-        **kwargs: dict,
-    ) -> tuple[tuple[State, ...], dict[str, NDArray[float]]]:
         ndim = self._ndim
         if chains is None:
             chains = 4 * ndim
-
-        if states is None:
-            seeds = np.random.SeedSequence(self._seed).spawn(n_parallel + 1)
-            rng = np.random.default_rng(seeds[0])
-            init = np.full((chains, ndim), self._init)
-            jitter = rng.uniform(0.99, 1.01, size=(n_parallel, chains, ndim))
-            init = init * jitter
-            rngs = list(map(np.random.default_rng, seeds[1:]))
-            states = [
-                State(i, random_state=j)
-                for i, j in zip(init, rngs, strict=True)
-            ]
-        else:
-            states = list(states)
-            if len(states) != n_parallel:
-                raise ValueError('states number should match n_parallel')
-            if not all(isinstance(s, State) for s in states):
-                raise ValueError('states must be sequence of emcee State')
-            for s in states:
-                if s.coords.shape != (chains, ndim):
-                    raise ValueError(
-                        f"states' coords must have shape ({chains}, {ndim})"
-                    )
-                s.log_prob = None
-                s.blobs = None
-            warmup = 0
-
+        if tune is None:
+            tune = False
         log_prob_fn = self._log_prob_with_blobs
         blobs_dtype = self._blobs_dtype
 
-        def run_sampler(sampler_id, state, queue):
-            sampler = EnsembleSampler(
+        def sampling_fn(
+            sampler_id: int, state: EnsembleSamplerState, queue: Queue
+        ):
+            emcee_state = EmceeState(
+                coords=state.coords,
+                random_state=state.random_state,
+            )
+            sampler1 = Sampler(
                 chains,
                 ndim,
                 log_prob_fn,
+                pool=None,
+                args=None,
+                kwargs=None,
                 vectorize=True,
                 blobs_dtype=blobs_dtype,
-                **kwargs,
+                parameter_names=None,
+                **warmup_kwargs,
+            )
+            sampler2 = Sampler(
+                chains,
+                ndim,
+                log_prob_fn,
+                pool=None,
+                args=None,
+                kwargs=None,
+                vectorize=True,
+                blobs_dtype=blobs_dtype,
+                parameter_names=None,
+                **sampling_kwargs,
             )
             queue.put((sampler_id, 'warmup'))
-            for s in sampler.sample(
-                state,
+            for s in sampler1.sample(
+                emcee_state,
                 iterations=warmup,
                 tune=tune,
                 store=False,
                 progress=False,
             ):
-                state = s
+                emcee_state = s
                 queue.put((sampler_id, 'update'))
             queue.put((sampler_id, 'sample'))
-            for s in sampler.sample(
-                state,
+            for s in sampler2.sample(
+                emcee_state,
                 iterations=steps,
                 tune=tune,
                 thin_by=thinning,
                 store=True,
                 progress=False,
             ):
-                state = s
+                emcee_state = s
                 queue.put((sampler_id, 'update'))
             queue.put((sampler_id, 'finish'))
-            return sampler.get_blobs(), state
-
-        def progress_listener(queue, pbars, num_samplers):
-            finished = 0
-            while finished < num_samplers:
-                sampler_id, msg = queue.get()
-                if msg == 'update':
-                    pbars[sampler_id].update(1)
-                elif msg == 'warmup':
-                    pbars[sampler_id].set_description(
-                        f'Warm-up sampler {sampler_id}'
-                    )
-                elif msg == 'sample':
-                    pbars[sampler_id].set_description(
-                        f'Running sampler {sampler_id}',
-                    )
-                elif msg == 'finish':
-                    pbars[sampler_id].set_description(
-                        f'Finished sampler {sampler_id}',
-                    )
-                    pbars[sampler_id].close()
-                    finished += 1
-
-        old_method = mp.get_start_method()
-        if old_method != 'spawn':
-            mp.set_start_method('spawn', force=True)
-        else:
-            old_method = ''
-
-        pbars = {
-            i: tqdm(
-                total=warmup + steps,
-                desc='Initializing... ',
-                position=i,
-                disable=not progress,
+            samples = sampler2.get_blobs()
+            state = EnsembleSamplerState(
+                coords=emcee_state.coords,
+                random_state=emcee_state.random_state,
             )
-            for i in range(1, n_parallel + 1)
-        }
+            return samples, state
 
-        queue = mp.Manager().Queue()
-        listener_thread = threading.Thread(
-            target=progress_listener, args=(queue, pbars, n_parallel)
-        )
-        listener_thread.start()
+        return sampling_fn
 
-        with mp.Pool(processes=n_parallel) as pool:
-            results = []
-            for i in range(n_parallel):
-                r = pool.apply_async(
-                    run_sampler,
-                    args=(i + 1, states[i], queue),
-                )
-                results.append(r)
-            results = [r.get() for r in results]
-
-        listener_thread.join()
-
-        if old_method:
-            mp.set_start_method(old_method, force=True)
-
-        samples = [r[0] for r in results]
-        states = tuple(r[1] for r in results)
-        for s in states:
-            s.log_prob = None
-            s.blobs = None
-
-        # reshape samples from (n_step, n_walker) to (n_walker, n_step)
-        samples = list(map(np.transpose, samples))
-        # merge chains from the same sampler into a single one
-        samples = list(map(np.concatenate, samples))
-        # stack samples of different samplers
-        samples = np.vstack(samples)
-        return states, {i: samples[i] for i in samples.dtype.names}
+    def get_random_state(self, seed: int) -> Generator:
+        return np.random.default_rng(seed)

--- a/src/elisa/infer/samplers/ensemble/zeus.py
+++ b/src/elisa/infer/samplers/ensemble/zeus.py
@@ -67,7 +67,7 @@ class ZeusSampler(EnsembleSampler):
                 pool=None,
                 vectorize=True,
                 blobs_dtype=blobs_dtype,
-                **warmup_kwargs,
+                **sampling_kwargs,
             )
             queue.put((sampler_id, 'warmup'))
             for _ in sampler1.sample(

--- a/src/elisa/infer/samplers/ensemble/zeus.py
+++ b/src/elisa/infer/samplers/ensemble/zeus.py
@@ -1,3 +1,132 @@
-# TODO: add support for Zeus's ensemble slice sampler
-# class ZeusEnsembleSampler:
-#     pass
+from __future__ import annotations
+
+from itertools import permutations
+from typing import TYPE_CHECKING
+
+import numpy as np
+import zeus
+import zeus.ensemble as zeus_ensemble
+import zeus.moves as zeus_moves
+
+from elisa.infer.samplers.ensemble.base import (
+    EnsembleSampler,
+    EnsembleSamplerState,
+)
+
+if TYPE_CHECKING:
+    from multiprocessing import Queue
+
+    from numpy.typing import NDArray
+
+
+class ZeusSampler(EnsembleSampler):
+    def get_sampling_fn(
+        self,
+        chains: int,
+        warmup: int,
+        steps: int,
+        thinning: int,
+        tune: bool | None,
+        warmup_kwargs: dict,
+        sampling_kwargs: dict,
+    ):
+        ndim = self._ndim
+        if tune is None:
+            tune = True
+        warmup_kwargs.setdefault('verbose', False)
+        sampling_kwargs.setdefault('verbose', False)
+        log_prob_fn = self._log_prob_with_blobs
+        blobs_dtype = self._blobs_dtype
+
+        def sampling_fn(
+            sampler_id: int,
+            state: EnsembleSamplerState,
+            queue: Queue,
+        ):
+            np.random.set_state(state.random_state)
+            start = state.coords
+            sampler1 = zeus.EnsembleSampler(
+                chains,
+                ndim,
+                log_prob_fn,
+                args=None,
+                kwargs=None,
+                tune=tune,
+                pool=None,
+                vectorize=True,
+                blobs_dtype=blobs_dtype,
+                **warmup_kwargs,
+            )
+            sampler2 = zeus.EnsembleSampler(
+                chains,
+                ndim,
+                log_prob_fn,
+                args=None,
+                kwargs=None,
+                tune=tune,
+                pool=None,
+                vectorize=True,
+                blobs_dtype=blobs_dtype,
+                **warmup_kwargs,
+            )
+            queue.put((sampler_id, 'warmup'))
+            for _ in sampler1.sample(
+                start=start,
+                iterations=warmup,
+                progress=False,
+            ):
+                queue.put((sampler_id, 'update'))
+            if warmup:
+                start = sampler1.get_last_sample()
+            sampler1.reset()
+            queue.put((sampler_id, 'sample'))
+            for _ in sampler2.sample(
+                start=start,
+                iterations=steps,
+                thin_by=thinning,
+                progress=False,
+            ):
+                queue.put((sampler_id, 'update'))
+            queue.put((sampler_id, 'finish'))
+            samples = sampler2.get_blobs()
+            state = EnsembleSamplerState(
+                coords=sampler2.get_last_sample(),
+                random_state=np.random.get_state(legacy=True),
+            )
+            return samples, state
+
+        return sampling_fn
+
+    def get_random_state(self, seed: int) -> tuple:
+        return np.random.RandomState(seed).get_state(legacy=True)
+
+
+class DifferentialMove:
+    """Improved DifferentialMove of zeus for reproducibility."""
+
+    def __init__(self, tune=True, mu0=1.0):
+        self.tune: bool = tune
+        self.mu0: float = mu0
+        self._nsamples: int | None = None
+        self._perms: NDArray[int] | None = None
+        self._nperms: int | None = None
+
+    def get_direction(self, X: NDArray[float], mu: float):
+        nsamples = X.shape[0]
+        if nsamples != self._nsamples:
+            self._nsamples = nsamples
+            self._perms = np.array(list(permutations(np.arange(nsamples), 2)))
+            self._nperms = len(self._perms)
+
+        idx = np.random.choice(self._nperms, self._nsamples, replace=False)
+        pairs = self._perms[idx].T
+
+        if not self.tune:
+            mu = self.mu0
+
+        return 2.0 * mu * (X[pairs[0]] - X[pairs[1]]), self.tune
+
+
+# Monkey patching the DifferentialMove for reproducibility
+zeus_ensemble.DifferentialMove = DifferentialMove
+zeus_moves.DifferentialMove = DifferentialMove

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ def powerlaw_flux(powerlaw_fn) -> Callable:
     return _
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='function')
 def simulation() -> Data:
     """Simulate a simple power-law spectrum with a known flux and index."""
     # Setup simulation configuration


### PR DESCRIPTION
## Summary by Sourcery

Implement a unified base class for ensemble samplers, refactor the existing Emcee sampler to leverage it, integrate a new Zeus-based ensemble slice sampler, expose the `zeus` method in the fitting interface, and add tests to validate the new sampler while preserving random state.

New Features:
- Add `ZeusSampler` class to enable ensemble slice sampling via the `zeus` library with separate warmup and sampling configurations
- Expose a new `zeus` method in `BayesFit` for running zeus-based ensemble slice sampling

Enhancements:
- Introduce `EnsembleSampler` abstract base class to consolidate common logic for emcee and zeus samplers
- Refactor `EmceeSampler` to subclass the new base class and separate warmup vs sampling phase parameters
- Monkey-patch `zeus.moves.DifferentialMove` for reproducible differential moves

Tests:
- Add test cases for the new `zeus` sampler in `test_fit.py`
- Verify that global NumPy random state remains unchanged after running the fit