### PR TITLE
chore: update deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -47,7 +47,7 @@ jobs:
           python -m twine check --strict dist/*
 
       - name: Upload Source Distribution as Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: elisa
           path: dist/*
@@ -89,14 +89,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
 
       - name: Install XSPEC
         run: |
           mamba install xspec -c ${{ env.heasarc-channel }} -c conda-forge -y
 
       - name: Download Source Distribution
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           name: elisa
 
@@ -144,10 +144,10 @@ jobs:
       id-token: write
     steps:
       - name: Download Source Distribution
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           name: elisa
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.12.4
+        uses: pypa/gh-action-pypi-publish@v1.13.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,14 +6,14 @@ repos:
         exclude: notebooks/data/.+
       - id: end-of-file-fixer
         exclude: notebooks/data/.+
-        exclude_types: [json, binary]
+        exclude_types: [ json, binary ]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.12.11"
+    rev: "v0.14.8"
     hooks:
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+        args: [ --fix, --exit-non-zero-on-fix ]
       - id: ruff-format
   - repo: https://github.com/kynan/nbstripout
-    rev: "0.8.1"
+    rev: "0.8.2"
     hooks:
       - id: nbstripout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,12 +22,12 @@ classifiers = [
 dependencies = [
     "arviz~=0.22.0",
     "astropy>=5.3,<7.2",
-    "blackjax==1.2.5",
+    "blackjax==1.3",
     "corner~=2.2.2",
     "dill~=0.4.0",
     "emcee~=3.1.6",
-    "h5py~=3.14.0",
-    "iminuit~=2.31.1",
+    "h5py>=3.14,<3.16",
+    "iminuit>=2.31.1,<2.33",
     # equinox v0.13.0 is not compatible with jax v0.7.1
     "jax>=0.4.35,<=0.7.0",
     "jaxns~=2.6.9",
@@ -37,7 +37,7 @@ dependencies = [
     "numpy>=1.24.1",
     "numpyro>=0.16.1,<0.20",
     "optimistix~=0.0.10",
-    "prettytable>=3.12.0,<3.17",
+    "prettytable>=3.12.0,<3.18",
     "quadax>=0.2.6,<0.3",
     "scipy>=1.11.1,<1.17",
     "seaborn~=0.13.2",
@@ -74,7 +74,7 @@ docs = [
     "widgetsnbextension",
 ]
 test = [
-    "coverage[toml]>=7.8,<7.11",
+    "coverage[toml]>=7.8,<7.13",
     "pytest",
     "pytest-cov",
     "pytest-xdist",


### PR DESCRIPTION
Close #266, #267, #268, #269, #270, #272, #273, #274, #275, #276, #277
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates CI actions and pre-commit hooks, and relaxes/bumps several Python dependency constraints.
> 
> - **CI (GitHub Actions)**:
>   - Update `actions/setup-python` to `v6`, `actions/upload-artifact` to `v5`.
>   - Update `astral-sh/setup-uv` to `v7` and `actions/download-artifact` to `v6`.
>   - Update PyPI publish action to `pypa/gh-action-pypi-publish@v1.13.0`.
> - **Tooling**:
>   - Bump pre-commit hooks: `astral-sh/ruff-pre-commit` to `v0.14.8`, `kynan/nbstripout` to `0.8.2`.
> - **Dependencies (`pyproject.toml`)**:
>   - Bump/relax: `blackjax==1.3`, `h5py>=3.14,<3.16`, `iminuit>=2.31.1,<2.33`, `prettytable>=3.12.0,<3.18`.
>   - Tests: `coverage[toml]` upper bound to `<7.13`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52e3eb9584eadd7c20110667ae7f0c9d6a7b62d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->