### PR TITLE
Fix JAX devices setting

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,6 +67,10 @@ master_doc = 'index'
 
 add_module_names = False
 autodoc_member_order = 'bysource'
+autodoc_default_options = {
+    'exclude-members': 'Lock',
+}
+suppress_warnings = ['sphinx_autodoc_typehints.guarded_import']
 
 codeautolink_concat_default = True
 copybutton_selector = 'div:not(.output) > div.highlight pre'

--- a/src/elisa/infer/fit.py
+++ b/src/elisa/infer/fit.py
@@ -190,6 +190,7 @@ class Fit(ABC):
             # JAX devices must be set before importing optimistix
             # so we import it here
             import optimistix as optx
+
             lm_solver = optx.LevenbergMarquardt(
                 rtol=0.0, atol=1e-6, verbose=verbose
             )

--- a/src/elisa/infer/fit.py
+++ b/src/elisa/infer/fit.py
@@ -12,7 +12,6 @@ import arviz as az
 import jax
 import jax.numpy as jnp
 import numpy as np
-import optimistix as optx
 import xarray as xr
 from iminuit import Minuit
 from numpyro.infer import init_to_value
@@ -188,6 +187,9 @@ class Fit(ABC):
             self._lm = None
 
         if self._lm is None:
+            # JAX devices must be set before importing optimistix
+            # so we import it here
+            import optimistix as optx
             lm_solver = optx.LevenbergMarquardt(
                 rtol=0.0, atol=1e-6, verbose=verbose
             )

--- a/src/elisa/infer/helper.py
+++ b/src/elisa/infer/helper.py
@@ -9,7 +9,6 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import numpyro
-import optimistix as optx
 from jax import lax
 from numpyro import handlers
 from numpyro.infer.util import constrain_fn, unconstrain_fn
@@ -134,6 +133,10 @@ def check_params(
 
 def get_helper(fit: Fit) -> Helper:
     """Get helper functions for fitting."""
+    # JAX devices must be set before importing optimistix
+    # so we import it here
+    import optimistix as optx
+
     model_info: ModelInfo = fit._model_info
     data: dict[str, FixedData] = fit._data
     model: dict[str, CompiledModel] = fit._model

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -111,10 +111,7 @@ def test_default_import_device_count():
     expected = _get_int(payload, 'expected')
     xla_flags = _get_str(payload, 'xla_flags')
     assert count == expected
-    assert (
-        f'--xla_force_host_platform_device_count={expected}'
-        in xla_flags
-    )
+    assert f'--xla_force_host_platform_device_count={expected}' in xla_flags
 
 
 def test_set_cpu_cores_after_default_import():
@@ -164,7 +161,4 @@ def test_set_cpu_cores_after_default_import():
     expected = _get_int(payload, 'expected')
     xla_flags = _get_str(payload, 'xla_flags')
     assert count == expected
-    assert (
-        f'--xla_force_host_platform_device_count={expected}'
-        in xla_flags
-    )
+    assert f'--xla_force_host_platform_device_count={expected}' in xla_flags

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+def _parse_payload(stdout: str) -> dict[str, object]:
+    lines = [line for line in stdout.splitlines() if line.strip()]
+    if not lines:
+        raise AssertionError('no stdout from subprocess')
+    return json.loads(lines[-1])
+
+
+def _run_subprocess(script: str) -> dict[str, object]:
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env.pop('XLA_FLAGS', None)
+    env['JAX_PLATFORM_NAME'] = 'cpu'
+
+    existing_pythonpath = env.get('PYTHONPATH')
+    if existing_pythonpath:
+        env['PYTHONPATH'] = f'{repo_root}{os.pathsep}{existing_pythonpath}'
+    else:
+        env['PYTHONPATH'] = str(repo_root)
+
+    result = subprocess.run(
+        [sys.executable, '-c', textwrap.dedent(script)],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+        env=env,
+    )
+    return _parse_payload(result.stdout)
+
+
+def _skip_if_needed(payload: dict[str, object]) -> None:
+    if payload.get('skipped'):
+        reason = payload.get('reason')
+        if not isinstance(reason, str):
+            reason = 'skipped by subprocess'
+        pytest.skip(reason)
+
+
+def _get_int(payload: dict[str, object], key: str) -> int:
+    value = payload.get(key)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    raise AssertionError(f'payload[{key!r}] is not an int')
+
+
+def _get_str(payload: dict[str, object], key: str) -> str:
+    value = payload.get(key)
+    if isinstance(value, str):
+        return value
+    if value is None:
+        return ''
+    return str(value)
+
+
+def test_default_import_device_count():
+    """Ensure default import sets JAX device count on CPU."""
+    script = """\
+    import json
+    import multiprocessing as mp
+    import os
+    import sys
+
+    os.environ.pop("XLA_FLAGS", None)
+    os.environ["JAX_PLATFORM_NAME"] = "cpu"
+
+    import elisa
+    import jax
+
+    total_cores = mp.cpu_count()
+    if total_cores < 2:
+        print(
+            json.dumps(
+                {
+                    "skipped": True,
+                    "reason": "cpu_count < 2",
+                    "total_cores": total_cores,
+                }
+            )
+        )
+        sys.exit(0)
+
+    expected = 4 if total_cores >= 4 else total_cores - 1
+    payload = {
+        "count": jax.local_device_count(),
+        "expected": expected,
+        "xla_flags": os.environ.get("XLA_FLAGS", ""),
+        "total_cores": total_cores,
+    }
+    print(json.dumps(payload))
+    """
+    payload = _run_subprocess(script)
+    _skip_if_needed(payload)
+
+    count = _get_int(payload, 'count')
+    expected = _get_int(payload, 'expected')
+    xla_flags = _get_str(payload, 'xla_flags')
+    assert count == expected
+    assert (
+        f'--xla_force_host_platform_device_count={expected}'
+        in xla_flags
+    )
+
+
+def test_set_cpu_cores_after_default_import():
+    """Ensure set_cpu_cores works after default import."""
+    script = """\
+    import json
+    import multiprocessing as mp
+    import os
+    import sys
+
+    os.environ.pop("XLA_FLAGS", None)
+    os.environ["JAX_PLATFORM_NAME"] = "cpu"
+
+    import elisa
+    from elisa.util.config import set_cpu_cores
+
+    total_cores = mp.cpu_count()
+    if total_cores < 2:
+        print(
+            json.dumps(
+                {
+                    "skipped": True,
+                    "reason": "cpu_count < 2",
+                    "total_cores": total_cores,
+                }
+            )
+        )
+        sys.exit(0)
+
+    expected = 2
+    set_cpu_cores(expected)
+
+    import jax
+
+    payload = {
+        "count": jax.local_device_count(),
+        "expected": expected,
+        "xla_flags": os.environ.get("XLA_FLAGS", ""),
+        "total_cores": total_cores,
+    }
+    print(json.dumps(payload))
+    """
+    payload = _run_subprocess(script)
+    _skip_if_needed(payload)
+
+    count = _get_int(payload, 'count')
+    expected = _get_int(payload, 'expected')
+    xla_flags = _get_str(payload, 'xla_flags')
+    assert count == expected
+    assert (
+        f'--xla_force_host_platform_device_count={expected}'
+        in xla_flags
+    )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches numerical optimization setup and environment-driven JAX configuration; incorrect timing could change device selection or break LM-based fits, but the change is localized and covered by new subprocess tests.
> 
> **Overview**
> Fixes JAX device configuration ordering issues by **removing eager `optimistix` imports** and importing it lazily inside the LM optimization path (`Fit._optimize_lm`) and `get_helper`, ensuring device-related env/config (e.g., `XLA_FLAGS`/device count) is applied first.
> 
> Adds subprocess-based tests (`tests/test_config.py`) that validate default `elisa` import sets the expected CPU `jax.local_device_count()` via `--xla_force_host_platform_device_count`, and that `set_cpu_cores()` still works when called after importing `elisa`. Documentation build config is also adjusted to exclude `Lock` from autodoc and suppress a guarded-import warning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a3d3e0c67c24be95d250337f8caa1dc0168a96c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>7a3d3e0</u></sup><!-- /BUGBOT_STATUS -->