### PR TITLE
ci: run checks for documentation pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,7 @@ on:
       - "docs/**"
       - "CITATION.bib"
       - "README.md"
-  pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "CITATION.bib"
-      - "README.md"
+  pull_request: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- run the CI workflow for every pull request, including documentation-only changes
- keep the existing `push` path exclusions unchanged
- leave all CI jobs and test commands unchanged

## Why

The active branch ruleset requires the test matrix and Codecov statuses. Documentation-only pull requests are currently excluded by `pull_request.paths-ignore`, so those required contexts are never reported and the pull request remains blocked.

## Validation

- the diff is limited to `.github/workflows/ci.yml`
- the branch is one commit ahead of `main` and zero commits behind
- this pull request changes a workflow file, so the existing CI workflow is eligible to run