### PR TITLE
ci: keep coverage baseline and VCS metadata complete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,6 @@ on:
       - main
     tags:
       - "*"
-    paths-ignore:
-      - "docs/**"
-      - "CITATION.bib"
-      - "README.md"
   pull_request: {}
 
 concurrency:
@@ -26,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
Summary:
- run CI on every main push so documentation-only merges retain a Codecov baseline
- fetch full Git history in the build job so hatch-vcs resolves versions from repository tags

Validation:
- Ruby YAML parser: passed
- git diff --check: passed
- change scope: .github/workflows/ci.yml only