### PR TITLE
fix: improve nested-sampling posterior exports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,9 @@ version.source = "vcs"
 [tool.pytest]
 ini_options.addopts = "-v -n auto --cov --cov-report=xml --junitxml=junit.xml"
 ini_options.testpaths = ["tests"]
+ini_options.markers = [
+    "slow: full nested-sampling pipeline tests (tens of seconds)",
+]
 
 [tool.ruff]
 line-length = 79

--- a/src/elisa/infer/fit.py
+++ b/src/elisa/infer/fit.py
@@ -1642,6 +1642,8 @@ class BayesFit(Fit):
         ess: int = 3000,
         ignore_nan: bool = False,
         *,
+        ess_multiplier: float | None = None,
+        equal_weight_boost: float | None = None,
         constructor_kwargs: dict | None = None,
         termination_kwargs: dict | None = None,
     ) -> PosteriorResult:
@@ -1660,6 +1662,20 @@ class BayesFit(Fit):
             .. warning::
                 Setting ``ignore_nan=True`` may fail to spot potential issues
                 with model computation.
+        ess_multiplier : float, optional
+            The multiplier ``k`` in the target-draws rule
+
+                expected equal-weight draws = k * weighted_ess
+
+            where ``weighted_ess`` is the native (unequal-weight) effective
+            sample size of the posterior.  Nautilus' ``equal_weight_boost`` is
+            chosen adaptively to target ``reff ~ 1 / k``.  The default is 2,
+            and values must be finite and ``>= 1``.
+        equal_weight_boost : float, optional
+            Explicit override of nautilus' ``equal_weight_boost``.  When set,
+            the adaptive rule is bypassed and this exact multiplier is used
+            (``1.0`` reproduces the previous behaviour).  ``reff`` is reported
+            as ``min(1.0, ess / n_draws)``.
         constructor_kwargs : dict, optional
             Extra parameters passed to
             :class:`nautilus.Sampler`.
@@ -1689,18 +1705,25 @@ class BayesFit(Fit):
             **constructor_kwargs,
         )
         t0 = time.time()
-        samples = sampler.run(**termination_kwargs)
+        samples = sampler.run(
+            ess_multiplier=ess_multiplier,
+            equal_weight_boost=equal_weight_boost,
+            **termination_kwargs,
+        )
         print(f'Sampling completed in {time.time() - t0:.2f} s')
 
         # format posterior samples
         samples = jax.tree.map(lambda x: x[None], samples)
 
-        # effective sample size
-        ess_overall = sampler.ess
+        # effective sample size: report the native (weighted) ESS, rounded to
+        # int for the public ``result.ess`` contract.
+        ess_overall = int(sampler.ess)
         ess = dict.fromkeys(self._helper.params_names['all'], ess_overall)
-        # relative mcmc efficiency
-        total_sample = len(samples[self._helper.params_names['all'][0]])
-        reff = float(ess_overall / total_sample)
+        # Relative efficiency for PSIS-LOO. It uses the same integer ESS as
+        # ``result.ess`` so the public contract is
+        # round-trip consistent: reff == min(1, result.ess[p] / n_draws).
+        n_draws = sampler.n_draws
+        reff = float(min(1.0, ess_overall / n_draws))
         # model evidence
         lnZ = (sampler.lnZ, None)
         return self._generate_results(
@@ -1791,11 +1814,21 @@ class BayesFit(Fit):
         samples = jax.tree.map(lambda x: x[None], samples)
 
         # effective sample size
-        ess_overall = sampler.ess
+        ess_overall = int(sampler.ess)
         ess = dict.fromkeys(self._helper.params_names['all'], ess_overall)
-        # relative mcmc efficiency
-        total_sample = len(samples[self._helper.params_names['all'][0]])
-        reff = float(ess_overall / total_sample)
+        # Relative efficiency for the equal-weight posterior export.
+        # ``ultranest.results['samples']`` is produced by ``resample_equal``,
+        # i.e. it is an *equal-weight* posterior; the native weighted draws
+        # live under ``results['weighted_samples']``.  elisa stores the
+        # equal-weight export, so the correct counting axis after the
+        # ``x[None]`` chain-axis wrap is ``shape[1]`` and ``reff`` is the
+        # *approximate* relative efficiency of the native ESS over that export:
+        #     reff = min(1, ess_overall / n_draws)
+        # ``ess_overall`` is the same integer-rounded value as ``result.ess``
+        # for a consistent public contract. The cap prevents assigning more
+        # independent information than the equal-weight export contains.
+        n_draws = samples[self._helper.params_names['all'][0]].shape[1]
+        reff = float(min(1.0, ess_overall / n_draws))
         # model evidence
         lnZ = sampler.lnZ
         return self._generate_results(

--- a/src/elisa/infer/samplers/ns/nautilus.py
+++ b/src/elisa/infer/samplers/ns/nautilus.py
@@ -68,7 +68,16 @@ def weighted_bases(log_w) -> float:
     constant offset added by weight normalisation.
     """
     log_w = np.asarray(log_w, dtype=float)
-    return float(np.exp(log_w - np.max(log_w)).sum())
+    if log_w.size == 0:
+        raise ValueError('`log_w` must not be empty')
+    if np.isnan(log_w).any() or np.isposinf(log_w).any():
+        raise ValueError('`log_w` must not contain NaN or positive infinity')
+
+    max_log_w = float(np.max(log_w))
+    if not math.isfinite(max_log_w):
+        raise ValueError('`log_w` must contain at least one finite value')
+
+    return float(np.exp(log_w - max_log_w).sum())
 
 
 def adaptive_equal_weight_boost(
@@ -78,6 +87,12 @@ def adaptive_equal_weight_boost(
 ) -> float:
     """Choose a boost targeting ``ess_multiplier * weighted_ess`` draws."""
     ess_multiplier = check_ess_multiplier(ess_multiplier)
+    weighted_ess = float(weighted_ess)
+    n_base = float(n_base)
+    if not math.isfinite(weighted_ess) or weighted_ess <= 0.0:
+        raise ValueError('`weighted_ess` must be finite and positive')
+    if not math.isfinite(n_base) or n_base <= 0.0:
+        raise ValueError('`n_base` must be finite and positive')
     return max(1.0, ess_multiplier * weighted_ess / n_base)
 
 

--- a/src/elisa/infer/samplers/ns/nautilus.py
+++ b/src/elisa/infer/samplers/ns/nautilus.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import warnings
 from typing import TYPE_CHECKING
 
@@ -8,6 +9,7 @@ import jax.numpy as jnp
 import multiprocess as mp
 import nautilus
 import nautilus.pool as nautilus_pool
+import numpy as np
 
 from elisa.infer.samplers.util import uniform_reparam_model
 
@@ -15,6 +17,68 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from numpy.typing import NDArray
+
+DEFAULT_ESS_MULTIPLIER = 2.0
+
+
+def resolve_ess_multiplier(k: float | None) -> float:
+    """Return and validate the requested or default ESS multiplier."""
+    if k is None:
+        k = DEFAULT_ESS_MULTIPLIER
+    return check_ess_multiplier(k)
+
+
+def check_ess_multiplier(k: float) -> float:
+    """Validate the target-draws multiplier: finite and ``>= 1``.
+
+    ``k`` controls the PSIS-LOO reff through ``reff ~ 1 / k``; values below 1
+    would allow reff > 1, which is why ``>= 1`` (not merely ``> 0``) is
+    enforced, matching the documentation.
+    """
+    k = float(k)
+    if not math.isfinite(k) or k < 1.0:
+        raise ValueError(
+            f'`ess_multiplier` must be finite and >= 1, got {k!r}'
+        )
+    return k
+
+
+def check_equal_weight_boost(b: float) -> float:
+    """Validate an explicit ``equal_weight_boost``: finite and positive."""
+    b = float(b)
+    if not math.isfinite(b) or b <= 0.0:
+        raise ValueError(
+            f'`equal_weight_boost` must be finite and positive, got {b!r}'
+        )
+    return b
+
+
+def weighted_bases(log_w) -> float:
+    """Expected number of equal-weight draws that nautilus would return at
+    ``equal_weight_boost == 1``.
+
+    From the nautilus ``posterior()`` source, point ``i`` is repeated a number
+    of times with mean ``exp(log_w_i - max(log_w)) * boost``, so by linearity
+    the expected total draw count at boost ``b`` is ``b * n_base`` where
+
+        n_base = sum(exp(log_w - max(log_w)))
+
+    ``log_w`` must contain the native unequal posterior weights returned by
+    ``posterior(equal_weight=False)``.  The formula is invariant to the
+    constant offset added by weight normalisation.
+    """
+    log_w = np.asarray(log_w, dtype=float)
+    return float(np.exp(log_w - np.max(log_w)).sum())
+
+
+def adaptive_equal_weight_boost(
+    weighted_ess: float,
+    n_base: float,
+    ess_multiplier: float,
+) -> float:
+    """Choose a boost targeting ``ess_multiplier * weighted_ess`` draws."""
+    ess_multiplier = check_ess_multiplier(ess_multiplier)
+    return max(1.0, ess_multiplier * weighted_ess / n_base)
 
 
 class NautilusSampler:
@@ -79,30 +143,93 @@ class NautilusSampler:
         if old_pool is not None:
             nautilus_pool.Pool = old_pool
 
-    def run(self, **kwargs) -> dict[str, NDArray[float]]:
+    def run(
+        self,
+        ess_multiplier: float | None = None,
+        equal_weight_boost: float | None = None,
+        **kwargs,
+    ) -> dict[str, NDArray[float]]:
         kwargs.setdefault('verbose', True)
         kwargs['discard_exploration'] = True
         sampler = self._sampler
         success = sampler.run(**kwargs)
-        if success:
-            u_samples, *_ = sampler.posterior(
-                return_as_dict=False,
-                equal_weight=True,
-            )
-            u_samples = jax.vmap(self._model_info.unravel)(u_samples)
-            samples = jax.vmap(self._model_info.postprocess_fn)(u_samples)
-            samples = jax.device_get(samples)
-            return samples
-        else:
+        if not success:
             raise RuntimeError(
                 'Sampling failed due to limits were reached, please set a '
                 'larger `n_like_max` or `timeout`. You can also resume the '
                 'sampler from previous one, providing `filepath` and `resume`.'
             )
 
+        # Native (weighted) posterior: the returned ``log_w`` here are the
+        # true posterior weights.  Calling with ``equal_weight=False`` is
+        # REQUIRED -- with ``equal_weight=True`` nautilus resets ``log_w`` to
+        # the uniform weights of the resampled posterior (see nautilus source).
+        _u_native, log_w_native, _log_l = sampler.posterior(
+            return_as_dict=False,
+            equal_weight=False,
+        )
+        n_base = weighted_bases(log_w_native)
+        weighted_ess = float(sampler.n_eff)
+
+        if equal_weight_boost is None:
+            ess_multiplier = resolve_ess_multiplier(ess_multiplier)
+            # Expected number of equal-weight draws at boost b is b * n_base,
+            # so pick b to make the expected draw count k * weighted_ess:
+            #   E[draws] = b * n_base = k * weighted_ess
+            #   reff (PSIS-LOO) = weighted_ess / n_draws ~ 1 / k
+            equal_weight_boost = adaptive_equal_weight_boost(
+                weighted_ess,
+                n_base,
+                ess_multiplier,
+            )
+        else:
+            equal_weight_boost = check_equal_weight_boost(equal_weight_boost)
+
+        u_samples, _ew_logw, _log_l = sampler.posterior(
+            return_as_dict=False,
+            equal_weight=True,
+            equal_weight_boost=float(equal_weight_boost),
+        )
+        n_draws = len(u_samples)
+        if n_draws == 0:
+            raise RuntimeError(
+                '`equal_weight_boost` produced no posterior draws; increase '
+                'its value or use the adaptive default.'
+            )
+        u_samples = jax.vmap(self._model_info.unravel)(u_samples)
+        samples = jax.vmap(self._model_info.postprocess_fn)(u_samples)
+        samples = jax.device_get(samples)
+
+        # expose the quantities needed by fit.py for the PSIS-LOO reff contract
+        self._weighted_ess = weighted_ess
+        self._n_base = float(n_base)
+        self._equal_weight_boost = float(equal_weight_boost)
+        self._n_draws = n_draws
+        return samples
+
     @property
     def ess(self) -> int:
         return int(self._sampler.n_eff)
+
+    @property
+    def weighted_ess(self) -> float:
+        """Native (weighted) effective sample size of the posterior."""
+        return self._weighted_ess
+
+    @property
+    def n_draws(self) -> int:
+        """Number of equal-weight posterior draws exported by :meth:`run`."""
+        return self._n_draws
+
+    @property
+    def n_base(self) -> float:
+        """Expected draw count when ``equal_weight_boost=1``."""
+        return self._n_base
+
+    @property
+    def equal_weight_boost(self) -> float:
+        """Boost actually used by the last :meth:`run` call."""
+        return self._equal_weight_boost
 
     @property
     def lnZ(self) -> float | None:

--- a/tests/test_ns_adaptive.py
+++ b/tests/test_ns_adaptive.py
@@ -1,0 +1,171 @@
+"""Regression tests for nested-sampling posterior exports and efficiency."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from elisa import BayesFit
+from elisa.infer.samplers.ns import nautilus as _nautilus
+from elisa.infer.samplers.ns.nautilus import (
+    DEFAULT_ESS_MULTIPLIER,
+    adaptive_equal_weight_boost,
+    check_equal_weight_boost,
+    check_ess_multiplier,
+    resolve_ess_multiplier,
+    weighted_bases,
+)
+from elisa.models import PowerLaw
+
+SLOW = pytest.mark.slow
+
+
+def test_weighted_bases_matches_nautilus_rule():
+    rng = np.random.default_rng(0)
+    log_w = rng.normal(size=500)
+    expected = np.exp(log_w - np.max(log_w)).sum()
+    assert weighted_bases(log_w) == pytest.approx(expected)
+
+
+def test_check_ess_multiplier_accepts_ge_one():
+    assert check_ess_multiplier(1.0) == 1.0
+    assert check_ess_multiplier(2.0) == 2.0
+    assert check_ess_multiplier(1) == 1.0
+
+
+@pytest.mark.parametrize(
+    'bad', [0.0, 0.5, -1.0, math.nan, math.inf, -math.inf]
+)
+def test_check_ess_multiplier_rejects_invalid(bad):
+    with pytest.raises(ValueError):
+        check_ess_multiplier(bad)
+
+
+def test_check_equal_weight_boost_accepts_positive():
+    assert check_equal_weight_boost(0.1) == 0.1
+    assert check_equal_weight_boost(1.0) == 1.0
+
+
+@pytest.mark.parametrize('bad', [0.0, -1.0, math.nan, math.inf, -math.inf])
+def test_check_equal_weight_boost_rejects_invalid(bad):
+    with pytest.raises(ValueError):
+        check_equal_weight_boost(bad)
+
+
+def test_default_ess_multiplier(monkeypatch):
+    assert DEFAULT_ESS_MULTIPLIER == 2.0
+    assert resolve_ess_multiplier(None) == 2.0
+
+    monkeypatch.setattr(_nautilus, 'DEFAULT_ESS_MULTIPLIER', 5.0)
+    assert resolve_ess_multiplier(None) == 5.0
+
+    monkeypatch.setattr(_nautilus, 'DEFAULT_ESS_MULTIPLIER', 0.5)
+    with pytest.raises(ValueError):
+        resolve_ess_multiplier(None)
+
+
+def test_adaptive_boost_matches_target_draw_count():
+    n_base = 101.0
+    weighted_ess = 5100.5
+    multiplier = 2.0
+    boost = adaptive_equal_weight_boost(
+        weighted_ess,
+        n_base,
+        multiplier,
+    )
+    assert boost * n_base == pytest.approx(multiplier * weighted_ess)
+
+
+def test_adaptive_boost_grows_with_concentration():
+    weighted_ess = 2000.0
+    multiplier = 2.0
+    concentrated = adaptive_equal_weight_boost(
+        weighted_ess,
+        1.0,
+        multiplier,
+    )
+    broad = adaptive_equal_weight_boost(
+        weighted_ess,
+        500.0,
+        multiplier,
+    )
+    assert concentrated > broad >= 1.0
+
+
+def test_adaptive_boost_validates_multiplier():
+    with pytest.raises(ValueError):
+        adaptive_equal_weight_boost(100.0, 50.0, 0.5)
+
+
+def _fit(simulation, method='nautilus', **kwargs):
+    model = PowerLaw()
+    model.PowerLaw.K.log = True
+    return getattr(BayesFit(simulation, model, seed=100), method)(**kwargs)
+
+
+@SLOW
+def test_nautilus_default_boost_reff_roundtrip(simulation):
+    result = _fit(
+        simulation,
+        ess=300,
+        constructor_kwargs={'pool': 1},
+        termination_kwargs={'verbose': False},
+    )
+    parameter = 'PowerLaw.K'
+    n_draws = int(result.idata['posterior'][parameter].shape[1])
+    ess = result.ess[parameter]
+    assert n_draws >= ess
+    assert 0.0 < result.reff <= 1.0
+    assert result.reff == pytest.approx(min(1.0, ess / n_draws))
+
+
+@SLOW
+def test_nautilus_explicit_legacy_boost_clamps_reff(simulation):
+    result = _fit(
+        simulation,
+        ess=300,
+        equal_weight_boost=1.0,
+        constructor_kwargs={'pool': 1},
+        termination_kwargs={'verbose': False},
+    )
+    parameter = 'PowerLaw.K'
+    n_draws = int(result.idata['posterior'][parameter].shape[1])
+    ess = result.ess[parameter]
+    assert 0.0 < result.reff <= 1.0
+    assert result.reff == pytest.approx(min(1.0, ess / n_draws))
+
+
+@SLOW
+def test_nautilus_evidence_invariant_to_resampling(simulation):
+    result_a = _fit(
+        simulation,
+        ess=300,
+        ess_multiplier=1.0,
+        termination_kwargs={'verbose': False},
+        constructor_kwargs={'pool': 1},
+    )
+    result_b = _fit(
+        simulation,
+        ess=300,
+        ess_multiplier=5.0,
+        termination_kwargs={'verbose': False},
+        constructor_kwargs={'pool': 1},
+    )
+    assert np.isclose(result_a.lnZ[0], result_b.lnZ[0], rtol=1e-6)
+
+
+@SLOW
+def test_ultranest_reff_roundtrip(simulation):
+    result = _fit(
+        simulation,
+        method='ultranest',
+        ess=250,
+        print_result=False,
+    )
+    parameter = 'PowerLaw.K'
+    n_draws = int(result.idata['posterior'][parameter].shape[1])
+    ess = result.ess[parameter]
+    assert 0.0 < result.reff <= 1.0
+    assert result.reff == pytest.approx(min(1.0, ess / n_draws))

--- a/tests/test_ns_adaptive.py
+++ b/tests/test_ns_adaptive.py
@@ -29,6 +29,26 @@ def test_weighted_bases_matches_nautilus_rule():
     assert weighted_bases(log_w) == pytest.approx(expected)
 
 
+def test_weighted_bases_allows_zero_weight_points():
+    log_w = np.array([0.0, -1.0, -math.inf])
+    assert weighted_bases(log_w) == pytest.approx(1.0 + math.exp(-1.0))
+
+
+@pytest.mark.parametrize(
+    'log_w',
+    [
+        [],
+        [0.0, math.nan],
+        [0.0, math.inf],
+        [-math.inf, -math.inf],
+    ],
+    ids=['empty', 'nan', 'positive-infinity', 'all-negative-infinity'],
+)
+def test_weighted_bases_rejects_invalid_weights(log_w):
+    with pytest.raises(ValueError):
+        weighted_bases(log_w)
+
+
 def test_check_ess_multiplier_accepts_ge_one():
     assert check_ess_multiplier(1.0) == 1.0
     assert check_ess_multiplier(2.0) == 2.0
@@ -97,6 +117,24 @@ def test_adaptive_boost_grows_with_concentration():
 def test_adaptive_boost_validates_multiplier():
     with pytest.raises(ValueError):
         adaptive_equal_weight_boost(100.0, 50.0, 0.5)
+
+
+@pytest.mark.parametrize(
+    ('weighted_ess', 'n_base'),
+    [
+        (0.0, 1.0),
+        (-1.0, 1.0),
+        (math.nan, 1.0),
+        (math.inf, 1.0),
+        (1.0, 0.0),
+        (1.0, -1.0),
+        (1.0, math.nan),
+        (1.0, math.inf),
+    ],
+)
+def test_adaptive_boost_rejects_invalid_counts(weighted_ess, n_base):
+    with pytest.raises(ValueError):
+        adaptive_equal_weight_boost(weighted_ess, n_base, 2.0)
 
 
 def _fit(simulation, method='nautilus', **kwargs):


### PR DESCRIPTION
## Summary

- derive Nautilus equal-weight resampling density from the native unequal posterior weights
- target `k * weighted_ess` exported draws with a benchmarked default of `k=2`
- expose keyword-only `ess_multiplier` and `equal_weight_boost` controls
- compute Nautilus and UltraNest `reff` from the stored draw axis with the same integer ESS reported in `PosteriorResult`
- add fast contract tests and full Nautilus/UltraNest regression tests

## Motivation

Nautilus naturally produces an unequal-weight posterior. ELISA previously requested `posterior(equal_weight=True)` with Nautilus' default `equal_weight_boost=1` and discarded the native weights. At that setting each native point appears at most once, so the stored equal-weight posterior can contain far fewer draws than the sampler's weighted ESS and carries avoidable resampling noise.

The adaptive rule uses native `log_w`:

```text
n_base = sum(exp(log_w - max(log_w)))
boost = max(1, k * weighted_ess / n_base)
```

The default `k=2` targets about twice the weighted ESS in stored draws. Users can select a larger multiplier for tail-sensitive or multimodal analyses, or pass an explicit boost.

## Default selection

A fixed-native-posterior benchmark with 20 resamples per value gave:

| k | CI-width dispersion | draws | reff | wall time |
|---:|---:|---:|---:|---:|
| 1 | 0.0532 | 544 | 1.0000 | 30.54 s |
| 2 | 0.0322 | 1100 | 0.4945 | 30.37 s |
| 5 | 0.0160 | 2724 | 0.1997 | 30.09 s |
| 10 | 0.0113 | 5434 | 0.1001 | 30.36 s |

`k=2` reduces the measured equal-weight resampling dispersion by about 39% relative to `k=1`, doubles storage, and leaves sampler wall time and `lnZ` unchanged in this benchmark.

## Validation

- Ruff lint and format: passed
- adaptive/validation tests: `18 passed`
- Nautilus/UltraNest full-pipeline tests: `4 passed`
- sdist build: passed
- evidence is invariant across resampling multipliers in the deterministic E2E test

The host-wide non-slow suite reported `132 passed, 47 skipped, 15 failed`. Representative failures reproduce on an unmodified `upstream/main` archive and come from the current local environment (XLA device configuration, Optimistix API drift, and multiprocessing startup); the focused tests above pass on the same host.

## Related CI run

The earlier [Lowest Version Deps failure](https://github.com/wcxve/elisa/actions/runs/32627694609/job/97165539983) terminated in `jaxlib.cpu_feature_guard` with `Illegal instruction` while xdist workers imported `xspex`. The immediately preceding run used the same runner image and dependency set successfully. Re-running the failed workflow produced a fully successful second attempt across Lowest Version Deps, Linux Python 3.14, and macOS Python 3.14, so this PR does not add a speculative workflow workaround.
