### PR TITLE
ci: run full compatibility matrix on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,7 @@ jobs:
   compatibility:
     name: Full Compatibility Matrix
     if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Run the existing full compatibility matrix after pushes to main. The scheduled, manual, and tag triggers remain unchanged.